### PR TITLE
fix(data-privacy): stop redaction destroying opaque machine identifiers

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -393,3 +393,43 @@ paths = [
 description = "RFC 6455 sample Sec-WebSocket-Key in the voice listener handshake tests, a client-invented nonce"
 targetRules = ["generic-api-key"]
 regexes = ['''^dGhlIHNhbXBsZSBub25jZQ==$''']
+
+# The bech32 test vectors in the bitcoin-address suite, which prove the
+# recognizer rejects a witness version or a witness program bitcoin does not
+# allow. They come in pairs: the same construction at a value bitcoin permits
+# and at one it does not, so the permitted member validating is what shows the
+# other is rejected for its version or its program rather than for a checksum
+# that never lined up.
+#
+# Naming them, as this file requires. None is a credential and none can become
+# one: a bech32 string is a PUBLIC address, the thing you hand out to be paid,
+# and these were generated for this test rather than observed. The rejected
+# members are not bitcoin addresses at all — no wallet will parse them — and the
+# accepted members encode payloads of counted-up bytes, so they are well-formed
+# addresses to keys nobody holds. There is nothing to revoke, and nothing to
+# send anywhere.
+#
+# They cannot be assembled at run time the way the base64 fixture in the
+# identifier hold-out suite is. The checksum IS the thing under test, so a test
+# that computed it would be asserting one implementation against a copy of
+# itself; the literal is what makes the vector a vector.
+#
+# gitleaks' `generic-api-key` rule fires on the `const token = "<entropy>"`
+# shape and cannot tell an address from a key.
+#
+# Scoped by VALUE and ANCHORED, for the reason given above the block before it:
+# a substring allowlist would also permit a real secret that merely starts with
+# these characters.
+[[allowlists]]
+description = "Generated bech32 vectors in the bitcoin-address tests; public addresses to keys nobody holds"
+targetRules = ["generic-api-key"]
+regexes = [
+  '''^bc1pr23clxd5mzfsh79vn6pg0kaytjeq8w4u8x8jd8$''',
+  '''^bc13r23clxd5mzfsh79vn6pg0kaytjeq8w4un2kxzn$''',
+  '''^bc1pqvwl8xs0$''',
+  '''^bc1pqdnfnnda$''',
+  '''^bc1pqv9pzxqlyckngw6zf9g9whn9d3eh4qvg37tfmf9tk2uup37w6hww86h3lrlsvrg5rvlw2s2x$''',
+  '''^bc1pqv9pzxqlyckngw6zf9g9whn9d3eh4qvge0qxlk$''',
+  '''^bc1qqv9pzxqlyckngw6zf9g9whn9dsaqaxas$''',
+  '''^bc1qqv9pzxqlyckngw6zf9g9whn9d3eh4qvg8d8phl$''',
+]

--- a/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.analysisSubmission.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.analysisSubmission.test.ts
@@ -210,4 +210,45 @@ describe("OtlpSpanPiiRedactionService what still reaches analysis", () => {
       expect(submitted()).toContain("raised by Jane");
     });
   });
+
+  // The two suites above key their attributes by the real name, so the
+  // `attributeNames` lookup on the submission path falls through to the raw key
+  // and is never exercised: deleting it leaves them green. The native path has
+  // its own cover next door; this is the submission half.
+  //
+  // The value has to be one the hold-out decides on the NAME alone, or the test
+  // proves nothing. A decimal identifier is withheld under every spelling
+  // because a phone detector claims it, and a 32-char hex is withheld by the
+  // value rule wherever it appears — under either, both halves of the contrast
+  // below go missing and the lookup could be deleted unnoticed. Twelve hex
+  // characters is under the opaque-run floor and carries no PII shape, so the
+  // reserved name is the only thing that can hold it back.
+  describe("given attributes keyed by a flattened name", () => {
+    /** @scenario "A flattened attribute is held out under its real name" */
+    it("resolves each key through attributeNames, holding out only the reserved one", async () => {
+      const { service, submitted } = makeService();
+      // mulberry32, seed 20260912, hex alphabet, draws 97-108.
+      const address = "c9eae7b78cb2";
+      const log = {
+        body: "request handled for Jane Doe",
+        attributes: {
+          "attributes.0.value": address,
+          "attributes.1.value": address,
+        },
+        attributeNames: {
+          "attributes.0.value": "metadata.trace_id",
+          "attributes.1.value": "app.correlation",
+        },
+        resourceAttributes: {},
+      };
+
+      await service.redactLog(log, "STRICT", TENANT);
+
+      // One copy, not none and not both: the reserved name withheld its copy
+      // and the unreserved one still went out. Without the lookup neither key
+      // is reserved and both copies leave.
+      expect(submitted().filter((value) => value === address)).toHaveLength(1);
+      expect(submitted()).toContain("request handled for Jane Doe");
+    });
+  });
 });

--- a/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.analysisSubmission.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.analysisSubmission.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The analysis service is the boundary under test: what LEAVES the process is
+// the observable contract, so the batch function is spied on and the rest of
+// the redaction stack runs for real.
+//
+// Every trace and span identifier below is GENERATED, never observed: each is
+// drawn from the same mulberry32 generator the corpus tests use, seeded
+// 20260912, over the hex alphabet. Nothing here names a real trace.
+vi.mock("~/server/featureFlag", () => ({
+  featureFlagService: { isEnabled: vi.fn(async () => false) },
+}));
+
+vi.mock("~/server/tracer/collector/piiCheck", () => ({
+  batchPresidioClearPII: vi.fn(),
+  googleDLPClearPII: vi.fn(),
+  PRESIDIO_STRICT_ENTITIES: ["PERSON", "LOCATION", "EMAIL_ADDRESS"],
+}));
+
+import { isIdentifierShapedValue } from "~/server/data-privacy/redaction/identifierHoldout";
+import {
+  DECIMAL_TRACE_ID_READ_AS_A_PHONE_NUMBER,
+  makeService,
+  nameCorpus,
+  spanWith,
+  TENANT,
+} from "./span-pii-redaction.identifierHoldout.harness";
+
+/**
+ * What still REACHES the analysis service: prose, names, and the corpora that
+ * put a number on the hold-out's two residuals. The suite next door asserts what
+ * the same rule keeps; this one is the other half, and the corpora are what stop
+ * either half being widened without the cost showing up.
+ */
+describe("OtlpSpanPiiRedactionService what still reaches analysis", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.LANGWATCH_DATA_PRIVACY_ENFORCEMENT;
+  });
+
+  describe("given an attribute that carries prose", () => {
+    /** @scenario "Prose that holds a name is still sent for analysis" */
+    it("submits a sentence naming a person", async () => {
+      const { service, submitted } = makeService();
+      const sentence = "the ticket was raised by Jane Doe in Berlin";
+      const span = spanWith({ "langwatch.input": sentence });
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      expect(submitted()).toContain(sentence);
+    });
+
+    /** @scenario "A customer identifier that holds a person name is still sent for analysis" */
+    it("submits a user identifier attribute holding a person name", async () => {
+      const { service, submitted } = makeService();
+      const span = spanWith({ "langwatch.user_id": "Jane Doe" });
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      expect(submitted()).toContain("Jane Doe");
+    });
+
+    // Carrying an identifier is not the same as being one. A support message,
+    // a log line or an error string routinely quotes the trace id it is about,
+    // and a rule that held a value back as soon as it CONTAINED an opaque run
+    // would stop scanning all of them — storing the names in the clear, which
+    // is the failure this module exists to prevent arrived at from the other
+    // side. Both separators are covered because "_" and "-" split a run while
+    // a space does not, so the two spellings reach the rule differently.
+    /** @scenario "Prose that quotes an opaque identifier is still sent for analysis" */
+    it.each([
+      ["a prefixed identifier", "trace_49386409e80a37fa22dc518583b31932"],
+      ["a bare hex identifier", "49386409e80a37fa22dc518583b31932"],
+    ])("submits a sentence naming a person next to %s", async (_case, id) => {
+      const { service, submitted } = makeService();
+      const sentence = `Jane Doe in Berlin reported this on ${id}`;
+      const span = spanWith({ "app.support_note": sentence });
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      expect(submitted()).toContain(sentence);
+    });
+
+    // The hold-out reads a whole attribute value, so a name written as ONE
+    // token is the case it can swallow. A control that uses "Jane Doe" only
+    // passes because of the space and guards nothing; these are the forms that
+    // have no space to save them.
+    /** @scenario "A hyphenated or run-together name is still sent for analysis" */
+    it("submits names written with hyphens, with dots and with no separator", async () => {
+      const { service, submitted } = makeService();
+      const names = [
+        "Elise-Marin-Van-Toren",
+        "Gonzalez-Rodriguez-Maria",
+        "Wolfgang-Amadeus-Mozart",
+        "AnneMarieJohansson",
+        "maria.schmidt.1972",
+      ];
+      const span = spanWith(
+        Object.fromEntries(
+          names.map((value, index) => [`langwatch.user_id_${index}`, value]),
+        ),
+      );
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      const withheld = names.filter((name) => !submitted().includes(name));
+      expect(withheld).toEqual([]);
+    });
+
+    /** @scenario "A place written as one hyphenated token is still sent for analysis" */
+    it("submits a hyphenated place and a hyphenated street address", async () => {
+      const { service, submitted } = makeService();
+      const span = spanWith({
+        "patient.clinic": "Saint-Jean-Baptiste-Hospital",
+        "shipping.address_line": "Elm-Street-Apartment-4B",
+      });
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      expect(submitted()).toContain("Saint-Jean-Baptiste-Hospital");
+      expect(submitted()).toContain("Elm-Street-Apartment-4B");
+    });
+
+    // The figure quoted in the pull request comes from here. `heldByShapeRule`
+    // is not a second implementation of the hold-out: it calls the native
+    // engine's rule directly, to keep the size of the regression this fixed
+    // measured rather than remembered.
+    /** @scenario "A corpus of written names is still sent for analysis" */
+    it("submits every one of two thousand generated names", async () => {
+      const { service, submitted } = makeService();
+      const names = nameCorpus(4242);
+      const span = spanWith(
+        Object.fromEntries(
+          names.map((value, index) => [`langwatch.user_id_${index}`, value]),
+        ),
+      );
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      const singleToken = names.filter((name) => !name.includes(" "));
+      const heldByShapeRule = names.filter((name) =>
+        isIdentifierShapedValue(name),
+      );
+      const withheld = names.filter((name) => !submitted().includes(name));
+
+      expect(names).toHaveLength(2000);
+      expect(singleToken.length).toBeGreaterThan(1400);
+      expect(heldByShapeRule.length).toBeGreaterThan(700);
+      expect(withheld).toEqual([]);
+    });
+
+    it("submits a run-together name carried in the chat content itself", async () => {
+      const { service, submitted } = makeService();
+      const span = spanWith({ "gen_ai.prompt": "AnneMarieJohansson" });
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      expect(submitted()).toContain("AnneMarieJohansson");
+    });
+  });
+
+  // Logs and metrics reach the hold-out down a different path from spans: a
+  // flattened record rather than an OTLP attribute list. Both halves of the
+  // rule have to survive that trip, so each case below carries a hex value that
+  // only the VALUE rule can hold back and a decimal address under a reserved
+  // NAME that only the name half can — the hex one alone would pass with the
+  // reserved list deleted.
+  describe("given a log record", () => {
+    /** @scenario "Log attributes hold opaque identifiers back from analysis" */
+    it("submits the body but never the identifier attribute", async () => {
+      const { service, submitted } = makeService();
+      const traceId = "68b9a2bb9fe50f11959987b7bf94a7d9";
+      const decimalTraceId = DECIMAL_TRACE_ID_READ_AS_A_PHONE_NUMBER;
+      const log = {
+        body: "request handled for Jane Doe",
+        attributes: {
+          "app.correlation": traceId,
+          "metadata.trace_id": decimalTraceId,
+        },
+        resourceAttributes: {},
+      };
+
+      await service.redactLog(log, "STRICT", TENANT);
+
+      expect(submitted()).not.toContain(traceId);
+      expect(submitted()).not.toContain(decimalTraceId);
+      expect(submitted()).toContain("request handled for Jane Doe");
+    });
+  });
+
+  describe("given metric attributes", () => {
+    /** @scenario "Metric attributes hold opaque identifiers back from analysis" */
+    it("never submits an identifier attribute, and still submits prose", async () => {
+      const { service, submitted } = makeService();
+      const traceId = "68b9a2bb9fe50f11959987b7bf94a7d9";
+      const decimalTraceId = DECIMAL_TRACE_ID_READ_AS_A_PHONE_NUMBER;
+      const metric = {
+        attributes: {
+          "app.correlation": traceId,
+          "metadata.trace_id": decimalTraceId,
+          "app.note": "raised by Jane",
+        },
+        resourceAttributes: {},
+      };
+
+      await service.redactMetricAttributes(metric, "STRICT", TENANT);
+
+      expect(submitted()).not.toContain(traceId);
+      expect(submitted()).not.toContain(decimalTraceId);
+      expect(submitted()).toContain("raised by Jane");
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.identifierHoldout.harness.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.identifierHoldout.harness.ts
@@ -1,0 +1,235 @@
+/**
+ * The fixtures and the service harness the identifier hold-out suites share.
+ *
+ * Two suites read this: one asserts what the reserved names and the opaque-value
+ * rule KEEP, the other asserts what still reaches the analysis service. They are
+ * one behaviour seen from two sides, so they share a corpus generator and a
+ * service builder rather than two that could drift apart.
+ *
+ * The `vi.mock` calls stay in the suites: those are hoisted per module, so a
+ * mock declared here would not apply to the file importing it.
+ */
+
+import { vi } from "vitest";
+import {
+  EMPTY_AUDIENCE,
+  type ResolvedDataPrivacy,
+} from "~/server/data-privacy/dataPrivacy.types";
+import { createTenantId } from "~/server/event-sourcing/domain/tenantId";
+import type {
+  OtlpKeyValue,
+  OtlpResource,
+  OtlpSpan,
+} from "../../../event-sourcing/pipelines/trace-processing/schemas/otlp";
+import {
+  type BatchClearPIIFunction,
+  type DataPrivacyResolver,
+  OtlpSpanPiiRedactionService,
+} from "../span-pii-redaction.service";
+
+export const TENANT = createTenantId("project-web-app");
+
+export const STRICT_POLICY: ResolvedDataPrivacy = {
+  categories: {
+    input: { disposition: "capture", audience: { ...EMPTY_AUDIENCE } },
+    output: { disposition: "capture", audience: { ...EMPTY_AUDIENCE } },
+    system: { disposition: "capture", audience: { ...EMPTY_AUDIENCE } },
+    tools: { disposition: "capture", audience: { ...EMPTY_AUDIENCE } },
+  },
+  pii: { level: "strict", entities: [], exceptPatterns: [] },
+  secrets: { enabled: true, customPatterns: [] },
+  customAttributes: [],
+};
+
+export function resolverFor(policy: ResolvedDataPrivacy): DataPrivacyResolver {
+  return { getResolvedForProject: async () => policy };
+}
+
+/**
+ * A redaction service whose only mocked seam is the analysis call, so the rest
+ * of the stack runs for real. Returns the service, the spy, and `submitted()` —
+ * every string that left the process, flattened across batches, which is the
+ * observable contract these suites assert against.
+ */
+export function makeService(policy: ResolvedDataPrivacy = STRICT_POLICY) {
+  // Return null for every input: the analysis service reporting "nothing to
+  // change" keeps the stored values readable, so an assertion about what was
+  // STORED and one about what was SUBMITTED cannot be confused for each other.
+  const batchSpy = vi.fn<BatchClearPIIFunction>(async (texts) =>
+    texts.map(() => null),
+  );
+  const service = new OtlpSpanPiiRedactionService({
+    batchClearPII: batchSpy,
+    isLangevalsConfigured: true,
+    isProduction: false,
+    dataPrivacyResolver: resolverFor(policy),
+  });
+  const submitted = (): string[] =>
+    batchSpy.mock.calls.flatMap((call) => call[0] as string[]);
+  return { service, batchSpy, submitted };
+}
+
+export function spanWith(attributes: Record<string, string>): OtlpSpan {
+  const attrs: OtlpKeyValue[] = Object.entries(attributes).map(
+    ([key, value]) => ({ key, value: { stringValue: value } }),
+  );
+  return {
+    traceId: "abc123",
+    spanId: "def456",
+    name: "test-span",
+    kind: 1,
+    startTimeUnixNano: { low: 0, high: 0 },
+    endTimeUnixNano: { low: 0, high: 0 },
+    attributes: attrs,
+    events: [],
+    links: [],
+    status: {},
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+  } as unknown as OtlpSpan;
+}
+
+export function attr(span: OtlpSpan, key: string): string | undefined {
+  return (
+    span.attributes.find((a) => a.key === key)?.value.stringValue ?? undefined
+  );
+}
+
+export function resourceAttr(
+  resource: OtlpResource | null,
+  key: string,
+): string | undefined {
+  return (
+    resource?.attributes.find((a) => a.key === key)?.value.stringValue ??
+    undefined
+  );
+}
+
+/** A seeded generator, so a failing corpus names the same values on a re-run. */
+export function seededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function pick(
+  next: () => number,
+  alphabet: string,
+  length: number,
+): string {
+  return Array.from(
+    { length },
+    () => alphabet[Math.floor(next() * alphabet.length)]!,
+  ).join("");
+}
+
+export const HEX = "0123456789abcdef";
+export const CROCKFORD = "0123456789abcdefghjkmnpqrstvwxyz";
+export const DIGITS = "0123456789";
+
+/**
+ * A decimal trace identifier that a phone detector claims: a leading 1 and ten
+ * more digits is the international shape of a North American number, and a
+ * decimal identifier carries nothing that says otherwise.
+ *
+ * This is the fixture the reserved-name catalog is worth testing with. Across
+ * the decimal widths a bridge mints -- ten, twelve, thirteen, nineteen, twenty
+ * and thirty-two digits -- the reserved name changes the stored value in no
+ * other case, because every remaining digit recognizer either needs a context
+ * word next to the number or needs a payment-card checksum inside an issuer
+ * range. A test built on any of those widths passes with the catalog deleted
+ * and proves nothing. This one goes red.
+ *
+ * Generated from the suite's seed like every other identifier here, never
+ * observed in traffic.
+ */
+export const DECIMAL_TRACE_ID_READ_AS_A_PHONE_NUMBER = `1${pick(
+  seededRandom(20260912),
+  DIGITS,
+  10,
+)}`;
+
+/**
+ * The shapes an OTel pipeline actually emits, split by what the rule can
+ * promise about each. Trace ids and uuids — long enough that the rule holds them back for every
+ * value rather than merely for most. A run qualifies as hex only if it also
+ * carries a letter, since a run of nothing but digits is a card or an account
+ * number as far as this rule can tell; across thirty-two hex characters a draw
+ * with no letter at all happens about three times in ten million, so a leak
+ * here is a broken rule rather than an unlucky draw.
+ */
+export function unconditionalCorpus(seed: number): string[] {
+  const next = seededRandom(seed);
+  const corpus: string[] = [];
+  for (let i = 0; i < 300; i++) {
+    corpus.push(pick(next, HEX, 32));
+    corpus.push(
+      `${pick(next, HEX, 8)}-${pick(next, HEX, 4)}-4${pick(next, HEX, 3)}-a${pick(next, HEX, 3)}-${pick(next, HEX, 12)}`,
+    );
+  }
+  return corpus;
+}
+
+/**
+ * The short tokens, which clear the rule on a coin toss rather than on their
+ * shape: a sixteen-character span id drawn with no letter at all (about one in
+ * eighteen hundred) reads as a digit run, and a ULID qualifies on carrying two
+ * digits rather than on being hex. Both are submitted when the draw goes that
+ * way, so the assertion below is a rate and not a zero — an exact zero would be
+ * true of one seed and would claim something the rule does not deliver.
+ */
+export function shortTokenCorpus(seed: number): string[] {
+  const next = seededRandom(seed);
+  const corpus: string[] = [];
+  for (let i = 0; i < 600; i++) {
+    corpus.push(pick(next, HEX, 16));
+    corpus.push(`session_${pick(next, CROCKFORD, 26)}`);
+  }
+  return corpus;
+}
+
+export const NAME_PARTS = [
+  "Jean",
+  "Claude",
+  "Anne",
+  "Marie",
+  "Maria",
+  "Schmidt",
+  "Wolfgang",
+  "Amadeus",
+  "Mozart",
+  "Gonzalez",
+  "Rodriguez",
+  "Saint",
+  "Baptiste",
+  "Johansson",
+  "Pierre",
+  "Dupont",
+];
+
+/**
+ * Personal names in the forms that have no space to save them: hyphenated,
+ * dotted, and run together. This is the direction that regressed once, when the
+ * analysis path borrowed the native engine's shape rule, so it is generated
+ * rather than hand-picked.
+ */
+export function nameCorpus(seed: number): string[] {
+  const next = seededRandom(seed);
+  const names: string[] = [];
+  while (names.length < 2000) {
+    const parts = 2 + Math.floor(next() * 3);
+    const picked = Array.from(
+      { length: parts },
+      () => NAME_PARTS[Math.floor(next() * NAME_PARTS.length)]!,
+    );
+    const separator = [" ", "-", ".", ""][Math.floor(next() * 4)]!;
+    names.push(picked.join(separator));
+  }
+  return names;
+}

--- a/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.identifierHoldout.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.identifierHoldout.test.ts
@@ -1,0 +1,260 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The analysis service is the boundary under test: what LEAVES the process is
+// the observable contract, so the batch function is spied on and the rest of
+// the redaction stack runs for real.
+//
+// Every trace and span identifier below is GENERATED, never observed: each is
+// drawn from the same mulberry32 generator the corpus tests use, seeded
+// 20260912, over the hex alphabet. Nothing here names a real trace.
+vi.mock("~/server/featureFlag", () => ({
+  featureFlagService: { isEnabled: vi.fn(async () => false) },
+}));
+
+vi.mock("~/server/tracer/collector/piiCheck", () => ({
+  batchPresidioClearPII: vi.fn(),
+  googleDLPClearPII: vi.fn(),
+  PRESIDIO_STRICT_ENTITIES: ["PERSON", "LOCATION", "EMAIL_ADDRESS"],
+}));
+
+import { CollectorSpanUtils } from "~/server/traces/collectorSpan.utils";
+import {
+  attr,
+  DECIMAL_TRACE_ID_READ_AS_A_PHONE_NUMBER,
+  makeService,
+  resourceAttr,
+  STRICT_POLICY,
+  shortTokenCorpus,
+  spanWith,
+  TENANT,
+  unconditionalCorpus,
+} from "./span-pii-redaction.identifierHoldout.harness";
+
+/**
+ * Prose carrying a name and a place, which the analysis service must be offered.
+ * It is the control every hold-out assertion in this file is measured against:
+ * these tests assert that things were NOT submitted, and that is only evidence
+ * of a working hold-out if something WAS.
+ */
+const PROSE_THAT_MUST_BE_ANALYSED =
+  "the ticket was raised by Jane Doe in Berlin";
+
+/**
+ * What the hold-out KEEPS: an attribute value that is one opaque identifier, and
+ * an attribute under one of the reserved trace and span names carrying the
+ * address that name promises. Both are asserted on the stored value and on what
+ * was submitted, because a rule that kept the value but still sent it for
+ * analysis would leak it just the same.
+ */
+describe("OtlpSpanPiiRedactionService identifier hold-out before analysis", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.LANGWATCH_DATA_PRIVACY_ENFORCEMENT;
+  });
+
+  describe("given a span attribute whose whole value is one opaque identifier", () => {
+    /** @scenario "An opaque identifier attribute value is never sent for analysis" */
+    it("never submits a hex span id, and stores it unchanged", async () => {
+      const { service, submitted } = makeService();
+      const spanId = "f52185dd67918e00";
+      const span = spanWith({ "app.upstream_span": spanId });
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      expect(submitted()).not.toContain(spanId);
+      expect(attr(span, "app.upstream_span")).toBe(spanId);
+    });
+
+    /** @scenario "A corpus of opaque identifiers is never sent for analysis" */
+    it.each([
+      20260911, 99, 7,
+    ])("never submits a trace id or a uuid, at seed %i", async (seed) => {
+      const { service, submitted } = makeService();
+      const corpus = unconditionalCorpus(seed);
+      const span = spanWith({
+        ...Object.fromEntries(
+          corpus.map((value, index) => [`app.ref_${index}`, value]),
+        ),
+        // The positive control, in the same span as the corpus. Without it an
+        // empty submission list satisfies the assertion below, so a hold-out
+        // that worked and an analysis pass that never ran read identically —
+        // and the corpus generator now lives in another file, where it could
+        // start returning nothing without this suite noticing.
+        "app.support_note": PROSE_THAT_MUST_BE_ANALYSED,
+      });
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      expect(corpus).toHaveLength(600);
+      expect(submitted()).toContain(PROSE_THAT_MUST_BE_ANALYSED);
+      const leaked = corpus.filter((value) => submitted().includes(value));
+      expect(leaked).toEqual([]);
+    });
+
+    /** @scenario "A corpus of short opaque tokens is almost never sent for analysis" */
+    it.each([
+      20260911, 99, 7,
+    ])("submits fewer than one short token in a hundred, at seed %i", async (seed) => {
+      const { service, submitted } = makeService();
+      const corpus = shortTokenCorpus(seed);
+      const span = spanWith(
+        Object.fromEntries(
+          corpus.map((value, index) => [`app.token_${index}`, value]),
+        ),
+      );
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      const leaked = corpus.filter((value) => submitted().includes(value));
+      expect(leaked.length / corpus.length).toBeLessThan(0.01);
+    });
+  });
+
+  describe("given a reserved trace identifier attribute", () => {
+    /** @scenario "A reserved trace identifier attribute is never sent for analysis" */
+    it("never submits a decimal trace id, which no shape rule would hold back", async () => {
+      const { service, submitted } = makeService();
+      // A decimal trace id carries no letter, so the shape rules read it as
+      // digits rather than as an identifier. The reserved name is what keeps it.
+      const decimalTraceId = "17575001234540000091234567890123";
+      const span = spanWith({ "metadata.trace_id": decimalTraceId });
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      expect(submitted()).not.toContain(decimalTraceId);
+    });
+
+    /** @scenario "A reserved identifier attribute survives even when its value is all digits" */
+    it("stores a decimal trace id unchanged at the default level", async () => {
+      const { service, batchSpy } = makeService({
+        ...STRICT_POLICY,
+        pii: { level: "essential", entities: [], exceptPatterns: [] },
+      });
+      const decimalTraceId = "17575001234540000091234567890123";
+      const span = spanWith({ "metadata.otelTraceId": decimalTraceId });
+
+      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+
+      expect(attr(span, "metadata.otelTraceId")).toBe(decimalTraceId);
+      expect(batchSpy).not.toHaveBeenCalled();
+    });
+
+    // The reserved names are not a namespace anyone owns: attributes arrive on
+    // the ingestion endpoint spelled exactly as the sender wrote them. A rule
+    // that went on the name alone would let a sender turn the personal-data
+    // pass off for any value at all, and the value is stored before anyone
+    // could notice. The name has to be carrying something that could actually
+    // be the address it promises.
+    /** @scenario "A reserved trace identifier name holding an email address is redacted at the strict level" */
+    it("redacts an email address written under a reserved name, and never submits it in the clear", async () => {
+      const { service, submitted } = makeService();
+      const span = spanWith({ "metadata.trace_id": "jane@example.com" });
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      expect(attr(span, "metadata.trace_id")).toBe("[EMAIL_ADDRESS]");
+      expect(submitted()).not.toContain("jane@example.com");
+    });
+
+    /** @scenario "A reserved trace identifier name holding an email address is still redacted" */
+    it("redacts an email address written under a reserved name natively", async () => {
+      const { service } = makeService({
+        ...STRICT_POLICY,
+        pii: { level: "essential", entities: [], exceptPatterns: [] },
+      });
+      const span = spanWith({ "metadata.trace_id": "jane@example.com" });
+
+      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+
+      expect(attr(span, "metadata.trace_id")).toBe("[EMAIL_ADDRESS]");
+    });
+
+    // A decimal trace id and a card number are the same shape, so the reserved
+    // name cannot be a blanket exemption: it stands the shape-only detectors
+    // down, which is what it is for, and leaves the ones that can prove what
+    // they are looking at running. The control above it is the decimal trace id
+    // that must survive, which is what makes this a rule about proof rather
+    // than a rule about length.
+    /** @scenario "A card number written under a reserved trace identifier name is still redacted" */
+    it("redacts a valid card number written under a reserved name", async () => {
+      const { service } = makeService({
+        ...STRICT_POLICY,
+        pii: { level: "essential", entities: [], exceptPatterns: [] },
+      });
+      const span = spanWith({ "metadata.trace_id": "4111111111111111" });
+
+      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+
+      expect(attr(span, "metadata.trace_id")).toBe("[CREDIT_CARD]");
+    });
+
+    // The control is the same value under a name nobody reserved. Without it
+    // this test asserts that a value survives redaction, which almost every
+    // value does, and it would stay green with the catalog deleted. With it,
+    // the only difference between the two halves is the name, so the catalog is
+    // what is being measured.
+    /** @scenario "A decimal trace identifier a phone detector claims is kept under a reserved name" */
+    it.each([
+      ["the raw OTLP spelling", "metadata.trace_id"],
+      ["the spelling the REST collector writes", "langwatch.metadata.trace_id"],
+      // The canonicaliser folds `langwatch.trace.*` into `metadata.*` on the
+      // same list as `langwatch.metadata.*`, so a sender may spell it either
+      // way and the hold-out has to answer the same for both.
+      ["the trace namespace spelling", "langwatch.trace.trace_id"],
+    ])("keeps a decimal trace id a phone detector claims, under %s", async (_case, key) => {
+      const { service } = makeService({
+        ...STRICT_POLICY,
+        pii: { level: "essential", entities: [], exceptPatterns: [] },
+      });
+      const traceId = DECIMAL_TRACE_ID_READ_AS_A_PHONE_NUMBER;
+      const span = spanWith({
+        [key]: traceId,
+        "app.unreserved_ref": traceId,
+      });
+
+      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+
+      expect(attr(span, key)).toBe(traceId);
+      expect(attr(span, "app.unreserved_ref")).toBe("[PHONE_NUMBER]");
+    });
+  });
+
+  // Custom metadata does not reach redaction spelled the way the caller wrote
+  // it. The REST collector rewrites every key to `langwatch.metadata.<key>`
+  // before the span is dispatched, and the canonicalisation back to
+  // `metadata.<key>` happens in the projections, long after redaction has run
+  // and long after anything it destroyed is unrecoverable. So the spelling the
+  // catalog is consulted with is the prefixed one, for every first-party sender
+  // -- the REST collector and the SDKs behind it. A test that hand-writes
+  // `metadata.trace_id` exercises only what a raw OTLP caller can send.
+  //
+  // The resource is therefore built by the collector's own function rather than
+  // by this file, so the rewrite under test is the production one.
+  describe("given caller metadata rewritten by the REST collector", () => {
+    /** @scenario "Caller metadata keeps a reserved trace identifier through the REST collector rewrite" */
+    it("keeps a decimal trace id sent as caller metadata, and never submits it", async () => {
+      const { service, submitted } = makeService();
+      const traceId = DECIMAL_TRACE_ID_READ_AS_A_PHONE_NUMBER;
+      const resource = CollectorSpanUtils.buildResource({
+        reservedTraceMetadata: {},
+        customMetadata: { trace_id: traceId, request_ref: traceId },
+      });
+
+      expect(resourceAttr(resource, "langwatch.metadata.trace_id")).toBe(
+        traceId,
+      );
+
+      await service.redactSpan(spanWith({}), resource, "STRICT", TENANT);
+
+      expect(resourceAttr(resource, "langwatch.metadata.trace_id")).toBe(
+        traceId,
+      );
+      expect(submitted()).not.toContain(traceId);
+      // Same value, a name nobody reserved: the detector does fire here, so the
+      // assertion above is about the name and not about the value.
+      expect(resourceAttr(resource, "langwatch.metadata.request_ref")).toBe(
+        "[PHONE_NUMBER]",
+      );
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/_constants.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/_constants.ts
@@ -300,3 +300,22 @@ export const SPAN_TYPE_TO_GEN_AI_OP: Record<string, string> = {
   agent: "agent",
   rag: "retrieval",
 };
+
+/**
+ * The vendor namespaces whose subkeys canonicalise to `metadata.<bareKey>`.
+ *
+ * Both spellings mean the same thing to a sender and are folded to the same
+ * canonical name here, so anything that reasons about a metadata key by its
+ * name has to accept every prefix on this list.
+ *
+ * It matters beyond canonicalisation because redaction runs BEFORE the fold:
+ * the personal-data pass sees the prefixed spelling, and a namespace added here
+ * but not taught to `isReservedIdentifierAttributeKey` is a namespace whose
+ * trace identifiers are handed to the recognizers. That is why this is one
+ * exported constant and not a literal in each place — the copy that gets
+ * forgotten is the one that silently stops protecting anything.
+ */
+export const METADATA_SUBKEY_PREFIXES = [
+  "langwatch.metadata.",
+  "langwatch.trace.",
+] as const;

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/langwatch.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/langwatch.ts
@@ -25,7 +25,7 @@
  * - gen_ai.system_instructions (extracted from first system message)
  */
 
-import { ATTR_KEYS } from "./_constants";
+import { ATTR_KEYS, METADATA_SUBKEY_PREFIXES } from "./_constants";
 import { ALLOWED_SPAN_TYPES } from "./_extraction";
 import { isRecord } from "./_guards";
 import {
@@ -252,10 +252,6 @@ export class LangWatchExtractor implements CanonicalAttributesExtractor {
     // subkeys and normalize to metadata.{bareKey}.
     // Uses setAttr (not setAttrIfAbsent) so subkeys override blob fields.
     // ─────────────────────────────────────────────────────────────────────────
-    const METADATA_SUBKEY_PREFIXES = [
-      "langwatch.metadata.",
-      "langwatch.trace.",
-    ] as const;
     for (const prefix of METADATA_SUBKEY_PREFIXES) {
       for (const { key, value } of attrs.takeByPrefix(prefix)) {
         const bareKey = key.slice(prefix.length);

--- a/platform/app/src/server/app-layer/traces/span-pii-redaction.service.ts
+++ b/platform/app/src/server/app-layer/traces/span-pii-redaction.service.ts
@@ -13,6 +13,7 @@ import {
   redactStringNative,
 } from "~/server/data-privacy/redaction/applyContentRedaction";
 import { ESSENTIAL_PII_ENTITIES } from "~/server/data-privacy/redaction/essentialPii";
+import { isHeldOutIdentifierAttribute } from "~/server/data-privacy/redaction/identifierHoldout";
 import type { TenantId } from "~/server/event-sourcing/domain/tenantId";
 import {
   batchPresidioClearPII as defaultBatchPresidioClearPII,
@@ -691,6 +692,7 @@ export class OtlpSpanPiiRedactionService {
       body: string;
       attributes: Record<string, string>;
       resourceAttributes: Record<string, string>;
+      attributeNames?: Record<string, string>;
     },
     piiRedactionLevel: PIIRedactionLevel,
     lambda?: {
@@ -706,10 +708,13 @@ export class OtlpSpanPiiRedactionService {
     if (!options) return;
 
     const batch = this.createRedactionBatch();
+    // The body is free text, not an attribute value, so no hold-out applies:
+    // an identifier written in a sentence sits next to content that may well
+    // hold personal data.
     if (log.body) {
       batch.tryPush(log as unknown as Record<string, string>, "body", log.body);
     }
-    this.collectRecordEntries(batch, log.attributes);
+    this.collectRecordEntries(batch, log.attributes, log.attributeNames);
     this.collectRecordEntries(batch, log.resourceAttributes);
 
     await this.applyRedactionBatch(batch, options);
@@ -761,6 +766,7 @@ export class OtlpSpanPiiRedactionService {
     metric: {
       attributes: Record<string, string>;
       resourceAttributes: Record<string, string>;
+      attributeNames?: Record<string, string>;
     },
     piiRedactionLevel: PIIRedactionLevel,
     lambda?: {
@@ -776,7 +782,7 @@ export class OtlpSpanPiiRedactionService {
     if (!options) return;
 
     const batch = this.createRedactionBatch();
-    this.collectRecordEntries(batch, metric.attributes);
+    this.collectRecordEntries(batch, metric.attributes, metric.attributeNames);
     this.collectRecordEntries(batch, metric.resourceAttributes);
 
     await this.applyRedactionBatch(batch, options);
@@ -857,14 +863,39 @@ export class OtlpSpanPiiRedactionService {
     };
   }
 
+  /**
+   * The log and metric counterpart of {@link collectStringEntries}: the same
+   * identifier hold-out, over a flattened record rather than an OTLP list.
+   *
+   * `attributeNames` restores the real attribute name where the record is keyed
+   * by an addressing path instead, because the reserved-name half of the
+   * hold-out reads the name and a path would never match one.
+   *
+   * It is passed for `attributes` and deliberately not for `resourceAttributes`
+   * at every call site. The map belongs to the attribute record: it is keyed by
+   * that record's keys, so handing it to the resource record would resolve a
+   * resource key against an unrelated attribute path wherever the two collide.
+   * Resource attributes are keyed by their own names already and need no map.
+   * If one is ever needed, it has to be a SEPARATE field — reusing this one is
+   * the bug this note exists to prevent.
+   */
   private collectRecordEntries(
     batch: RedactionBatch,
     record: Record<string, string>,
+    attributeNames?: Record<string, string>,
   ): void {
     for (const key of Object.keys(record)) {
-      if (record[key]) {
-        batch.tryPush(record, key, record[key]!);
+      const value = record[key];
+      if (!value) continue;
+      if (
+        isHeldOutIdentifierAttribute({
+          key: attributeNames?.[key] ?? key,
+          value,
+        })
+      ) {
+        continue;
       }
+      batch.tryPush(record, key, value);
     }
   }
 
@@ -902,6 +933,12 @@ export class OtlpSpanPiiRedactionService {
    * Collects string attribute values into the entries array.
    * Enforces a cumulative character budget — once adding a value would
    * exceed piiRedactionMaxAttributeLength the value is skipped.
+   *
+   * Machine identifiers never leave the process (see
+   * {@link isHeldOutIdentifierAttribute}). Holding one back is NOT a skip: a
+   * skip means "this value may still hold personal data we did not scan for",
+   * which is what marks the span as partially redacted, and an opaque address
+   * holds none. So a held-out attribute sets neither flag.
    */
   private collectStringEntries(
     attributes: OtlpKeyValue[],
@@ -918,6 +955,14 @@ export class OtlpSpanPiiRedactionService {
         attr.value.stringValue !== null &&
         attr.value.stringValue.length > 0
       ) {
+        if (
+          isHeldOutIdentifierAttribute({
+            key: attr.key,
+            value: attr.value.stringValue,
+          })
+        ) {
+          continue;
+        }
         if (
           totalLength + attr.value.stringValue.length >
           this.deps.piiRedactionMaxAttributeLength

--- a/platform/app/src/server/data-privacy/redaction/__tests__/applyContentRedaction.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/applyContentRedaction.unit.test.ts
@@ -498,6 +498,105 @@ describe("redactAttributeNative on identifier-shaped values", () => {
   });
 });
 
+/**
+ * The reserved trace and span names buy an exemption the `_id` suffix rule
+ * cannot give, because `traceid` and `spanid` carry no underscore. That
+ * exemption has to read the VALUE for the same reason the personal-data
+ * exemption does: the OTLP endpoint forwards caller-written attribute names
+ * verbatim, so the name is an assertion by whoever sent the span and nothing
+ * more. A reserved name over a credential is not a trace address.
+ *
+ * The `_id` names below are the control. They are exempt by suffix, which is
+ * behaviour that predates the reserved list and is not what these assert.
+ */
+describe("redacting an attribute under a reserved trace identifier name", () => {
+  const DECIMAL_TRACE_ADDRESS = "1757500123454000091";
+
+  describe("given a value shaped like the address the name promises", () => {
+    /** @scenario "A reserved trace identifier name keeps the address it promises" */
+    it.each([
+      "metadata.traceid",
+      "langwatch.metadata.traceid",
+    ])("keeps it under %s", (key) => {
+      expect(
+        redactAttributeNative({
+          key,
+          value: DECIMAL_TRACE_ADDRESS,
+          policy: policy({}),
+        }).text,
+      ).toBe(DECIMAL_TRACE_ADDRESS);
+    });
+  });
+
+  describe("given a value that is not an address at all", () => {
+    /** @scenario "A reserved trace identifier name does not exempt a credential" */
+    it.each([
+      "metadata.traceid",
+      "langwatch.metadata.traceid",
+    ])("still runs the shape rules under %s", (key) => {
+      expect(
+        redactAttributeNative({
+          key,
+          value: SHAPED_TOKEN,
+          policy: policy({}),
+        }).text,
+      ).toBe("[SECRET]");
+    });
+
+    // The suffix rule is older than the reserved list and unchanged by it, so
+    // an `_id` name keeps its exemption whatever the value is. Asserting it
+    // here is what stops the value gate above being read as a change to that.
+    it("leaves the suffix rule's own exemption alone", () => {
+      expect(
+        redactAttributeNative({
+          key: "metadata.trace_id",
+          value: SHAPED_TOKEN,
+          policy: policy({}),
+        }).text,
+      ).toBe(SHAPED_TOKEN);
+    });
+  });
+
+  /**
+   * This is the one thing the reserved list does that nothing else does, so it
+   * is worth a test that fails if the list stops being consulted.
+   *
+   * The value is a decimal address short enough that the shape rule rejects it
+   * and a phone recognizer claims it, and the name carries no `_id` suffix, so
+   * neither of the two older exemptions can be what keeps it. The unreserved
+   * control is the same value under a name nobody reserved: it is redacted, so
+   * the difference measured here is the name and not the value.
+   */
+  describe("given a short decimal address no shape rule would hold back", () => {
+    const PHONE_SHAPED_ADDRESS = "12515420585";
+
+    /** @scenario "A reserved name keeps an address the shape rule is too short to see" */
+    it.each([
+      "metadata.traceid",
+      "langwatch.metadata.traceid",
+      "traceid",
+    ])("keeps it under %s", (key) => {
+      expect(
+        redactAttributeNative({
+          key,
+          value: PHONE_SHAPED_ADDRESS,
+          policy: policy({}),
+        }).text,
+      ).toBe(PHONE_SHAPED_ADDRESS);
+    });
+
+    it("redacts the same value under a name nobody reserved", () => {
+      expect(
+        redactAttributeNative({
+          key: "app.note",
+          value: PHONE_SHAPED_ADDRESS,
+          policy: policy({}),
+        }).text,
+      ).toBe("[PHONE_NUMBER]");
+    });
+  });
+});
+
 describe("redactStringNative with policy PII exceptions", () => {
   it("keeps a fully matched value and redacts everything else", () => {
     const p = policy({ exceptPatterns: ["00\\d{12}"] });

--- a/platform/app/src/server/data-privacy/redaction/__tests__/bitcoinAddress.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/bitcoinAddress.unit.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isBase58CheckAddress,
+  isBech32Address,
+  isBitcoinAddress,
+} from "../bitcoinAddress";
+
+/**
+ * The whole point of these validators is that they can tell a real address from
+ * a hex string of the same shape, so the vectors are real mainnet addresses and
+ * the negatives are single-character mutations of them. A validator that
+ * accepted its own mutations would be no better than the pattern it replaced.
+ */
+const P2PKH = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
+const P2SH = "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy";
+const SEGWIT_V0 = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+const TAPROOT =
+  "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr";
+
+/**
+ * The hex identifier the shape-only pattern used to call an address. Generated,
+ * not observed: the first draw from the corpus tests' `seededRandom(20260912)`
+ * over the hex alphabet that leads with "1" or "3" and carries no "0", so it
+ * sits inside the base58 alphabet. Both properties are what make it a negative
+ * worth asserting rather than a string the pattern would never have reached.
+ */
+const HEX_ID_SHAPED_LIKE_AN_ADDRESS = "13f895f8877e4bc5edc85c397fbd3668";
+
+/**
+ * One constructed payload written at three version bytes, so the checksums are
+ * built the same way and only the version differs. The hash160 is the first
+ * twenty bytes of a digest of a fixed phrase, not an observed address, and the
+ * two accepted members are what prove the rejected one is turned away for its
+ * version rather than for a checksum that was never going to line up.
+ *
+ * Version six is the member that matters: base58 renders it with a leading "3",
+ * so it satisfies the legacy pattern, and its checksum is as valid as the other
+ * two. Bitcoin mints no such address.
+ */
+const PAYLOAD_AT_V0 = "1F6gFLr6VjazEQvMSV5prBd3agThutz9S8";
+const PAYLOAD_AT_V5 = "3FnhAtLY3duNKacnZakRGoyyjCkRWLW4rY";
+const PAYLOAD_AT_V6 = "3f8J9zdpkpNF91ksb15jkwFmMi1N9Kyia4";
+
+/** Swaps one character so the checksum no longer covers the payload. */
+function mutate(address: string, index: number, replacement: string): string {
+  return address.slice(0, index) + replacement + address.slice(index + 1);
+}
+
+describe("given a base58check address", () => {
+  describe("when the address is real", () => {
+    it.each([
+      ["a pay-to-public-key-hash address", P2PKH],
+      ["a pay-to-script-hash address", P2SH],
+    ])("accepts %s", (_case, address) => {
+      expect(isBase58CheckAddress(address)).toBe(true);
+    });
+
+    /**
+     * The leading "1" is a zero byte, not a digit, and a decoder that drops it
+     * produces a 24-byte payload whose checksum still lines up by accident on
+     * some inputs. Keeping a P2PKH vector pins that the leading zeros survive.
+     */
+    it("decodes the leading zero byte rather than dropping it", () => {
+      expect(isBase58CheckAddress(P2PKH)).toBe(true);
+      expect(isBase58CheckAddress(P2PKH.slice(1))).toBe(false);
+    });
+  });
+
+  /**
+   * A checksum says the payload is intact, not that bitcoin would ever mint it.
+   * The version byte is the rest of the grammar: mainnet spends exactly two of
+   * the 256 values, and a token carrying any of the other 254 is not an address
+   * whatever its checksum does.
+   */
+  describe("when the version byte is not one bitcoin mints", () => {
+    it.each([
+      ["version zero, pay-to-public-key-hash", PAYLOAD_AT_V0],
+      ["version five, pay-to-script-hash", PAYLOAD_AT_V5],
+    ])("accepts the same payload at %s", (_case, address) => {
+      expect(isBase58CheckAddress(address)).toBe(true);
+    });
+
+    it("rejects a checksum valid token at version six", () => {
+      expect(isBase58CheckAddress(PAYLOAD_AT_V6)).toBe(false);
+    });
+
+    it("keeps that token out of the crypto verdict entirely", () => {
+      expect(isBitcoinAddress(PAYLOAD_AT_V6)).toBe(false);
+    });
+  });
+
+  describe("when the address has been altered", () => {
+    it.each([
+      ["a changed payload character", mutate(P2PKH, 5, "9")],
+      ["a changed checksum character", mutate(P2PKH, 33, "b")],
+      ["a character outside the alphabet", mutate(P2PKH, 5, "0")],
+      ["a truncated address", P2PKH.slice(0, -1)],
+      ["a hex string of the same length", HEX_ID_SHAPED_LIKE_AN_ADDRESS],
+    ])("rejects %s", (_case, address) => {
+      expect(isBase58CheckAddress(address)).toBe(false);
+    });
+  });
+});
+
+describe("given a bech32 address", () => {
+  describe("when the witness version matches the checksum constant", () => {
+    it("accepts a version zero address with a bech32 checksum", () => {
+      expect(isBech32Address(SEGWIT_V0)).toBe(true);
+    });
+
+    it("accepts a taproot address with a bech32m checksum", () => {
+      expect(isBech32Address(TAPROOT)).toBe(true);
+    });
+  });
+
+  /**
+   * BIP-350 pairs version zero with bech32 and every later version with
+   * bech32m. Accepting either constant for either version would make these two
+   * BIP-350 invalid vectors validate.
+   */
+  describe("when the witness version and the checksum constant disagree", () => {
+    it("rejects a version zero address carrying a bech32m checksum", () => {
+      expect(
+        isBech32Address("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kemeawh"),
+      ).toBe(false);
+    });
+
+    it("rejects a version one address carrying a bech32 checksum", () => {
+      expect(
+        isBech32Address(
+          "bc1p38j9r5y49hruaue7wxjce0updqjuyyx0kh56v8s25huc6995vvpql3jow4",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  /**
+   * A checksum is only as narrow as the grammar behind it. The witness version
+   * is read from a thirty-two character alphabet, and BIP-141 defines sixteen
+   * of those values; the other fifteen decode to no segwit program at all.
+   *
+   * The pair below is one payload written at two versions, so the checksums are
+   * built the same way and only the version differs. The version one member
+   * validating is what proves the version seventeen member is rejected for its
+   * version and not for a checksum that was never going to line up.
+   */
+  describe("when the witness version is one bitcoin does not define", () => {
+    const PAYLOAD_AT_V1 = "bc1pr23clxd5mzfsh79vn6pg0kaytjeq8w4u8x8jd8";
+    const PAYLOAD_AT_V17 = "bc13r23clxd5mzfsh79vn6pg0kaytjeq8w4un2kxzn";
+
+    it("accepts the same payload written at a version bitcoin does define", () => {
+      expect(isBech32Address(PAYLOAD_AT_V1)).toBe(true);
+    });
+
+    it("rejects a checksum valid token at version seventeen", () => {
+      expect(isBech32Address(PAYLOAD_AT_V17)).toBe(false);
+    });
+  });
+
+  /**
+   * The checksum covers the characters, not what they mean, so a string can
+   * clear it and still encode no output anyone could pay to. Every vector below
+   * is checksum-valid and rejected for its program; the two controls are the
+   * same construction at a length bitcoin allows, which is what makes each
+   * rejection attributable to the program rule rather than to the checksum.
+   *
+   * The version zero, sixteen-byte case is BIP-173's own invalid vector. The
+   * rest are constructed, because the published list has no checksum-valid
+   * member for the other shapes.
+   */
+  describe("when the witness program is not one bitcoin allows", () => {
+    it.each([
+      ["a one-byte program, below the two-byte floor", "bc1pqvwl8xs0"],
+      [
+        "a forty-one byte program, above the ceiling",
+        "bc1pqv9pzxqlyckngw6zf9g9whn9d3eh4qvg37tfmf9tk2uup37w6hww86h3lrlsvrg5rvlw2s2x",
+      ],
+      ["padding bits that are not zero", "bc1pqdnfnnda"],
+      [
+        "version zero at sixteen bytes, which is neither 20 nor 32",
+        "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
+      ],
+      [
+        "version zero at sixteen bytes, constructed",
+        "bc1qqv9pzxqlyckngw6zf9g9whn9dsaqaxas",
+      ],
+    ])("rejects %s", (_case, address) => {
+      expect(isBech32Address(address)).toBe(false);
+    });
+
+    it.each([
+      [
+        "version one at twenty bytes",
+        "bc1pqv9pzxqlyckngw6zf9g9whn9d3eh4qvge0qxlk",
+      ],
+      [
+        "version zero at twenty bytes",
+        "bc1qqv9pzxqlyckngw6zf9g9whn9d3eh4qvg8d8phl",
+      ],
+    ])("accepts the same construction at %s", (_case, address) => {
+      expect(isBech32Address(address)).toBe(true);
+    });
+  });
+
+  describe("when the address has been altered", () => {
+    it.each([
+      ["a changed data character", mutate(SEGWIT_V0, 10, "p")],
+      ["a character outside the charset", mutate(SEGWIT_V0, 10, "b")],
+      ["a truncated address", SEGWIT_V0.slice(0, -1)],
+      [
+        "mixed case, which BIP-173 forbids",
+        "bc1QW508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+      ],
+      ["nothing but the prefix", "bc1"],
+    ])("rejects %s", (_case, address) => {
+      expect(isBech32Address(address)).toBe(false);
+    });
+  });
+});
+
+describe("given either address form", () => {
+  it("routes by prefix and accepts every real vector", () => {
+    for (const address of [P2PKH, P2SH, SEGWIT_V0, TAPROOT]) {
+      expect(isBitcoinAddress(address)).toBe(true);
+    }
+  });
+
+  it("rejects a hex identifier that starts like an address", () => {
+    expect(isBitcoinAddress(HEX_ID_SHAPED_LIKE_AN_ADDRESS)).toBe(false);
+  });
+
+  /**
+   * BIP-173 defines an address as case-insensitive and QR encoders emit the
+   * uppercase form, because uppercase packs into an alphanumeric QR segment.
+   * The bech32 validator already reads it; only the prefix this function routes
+   * on was lowercase, which sent the uppercase form to the base58 decoder and
+   * got a rejection that looked like a verdict.
+   */
+  it("routes an uppercase segwit address to the bech32 validator", () => {
+    expect(isBitcoinAddress(SEGWIT_V0.toUpperCase())).toBe(true);
+    expect(isBitcoinAddress(TAPROOT.toUpperCase())).toBe(true);
+  });
+
+  /** Mixed case stays invalid: BIP-173 forbids it, in either router. */
+  it("still rejects a mixed case segwit address", () => {
+    expect(isBitcoinAddress("BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7Kv8f3t4")).toBe(
+      false,
+    );
+  });
+});

--- a/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.machineIdentifiers.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.machineIdentifiers.unit.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "vitest";
+
+import { redactEssentialPiiInText } from "../essentialPii";
+
+/**
+ * A seeded generator, so a corpus that fails names the same value on a re-run
+ * and a fix can be checked against the exact id that broke.
+ */
+function seededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function hexCorpus({
+  count,
+  length,
+  seed,
+}: {
+  count: number;
+  length: number;
+  seed: number;
+}): string[] {
+  const next = seededRandom(seed);
+  const digits = "0123456789abcdef";
+  return Array.from({ length: count }, () =>
+    Array.from({ length }, () => digits[Math.floor(next() * 16)]!).join(""),
+  );
+}
+
+const asAttributeValue = (text: string) =>
+  redactEssentialPiiInText({ text, isAttributeValue: true }).text;
+
+/**
+ * The genesis block address and the BIP-173 reference addresses: public
+ * constants with valid checksums, none belonging to anyone reachable.
+ */
+const REAL_P2PKH_ADDRESS = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
+const REAL_P2SH_ADDRESS = "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy";
+const REAL_BECH32_ADDRESS = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+/** BIP-350 reference: witness version 1, so a bech32m checksum, not bech32. */
+const REAL_TAPROOT_ADDRESS =
+  "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr";
+
+/**
+ * A 32-hex OTel trace id that the shape-only bitcoin pattern matches.
+ *
+ * Generated, not observed: the first draw from `seededRandom(20260912)` over
+ * the hex alphabet that leads with "1" or "3" and carries no "0", which is what
+ * puts it inside the base58 alphabet and so inside the pattern the defect fired
+ * on. Without those two properties the fixture would pass vacuously.
+ */
+const HEX_TRACE_ID_SHAPED_LIKE_AN_ADDRESS = "13f895f8877e4bc5edc85c397fbd3668";
+
+describe("the native essential-PII engine on machine identifiers", () => {
+  describe("given an attribute value that is one opaque trace identifier", () => {
+    /** @scenario "An opaque trace identifier survives redaction at the default level" */
+    it("keeps a hex trace id that the bitcoin pattern matches on shape", () => {
+      // Guard the guard: a fixture outside the base58 alphabet never reaches
+      // the pattern the defect fired on, so it would pass without proving
+      // anything. Pin the shape here so a future substitution cannot weaken it
+      // in silence.
+      expect(HEX_TRACE_ID_SHAPED_LIKE_AN_ADDRESS).toMatch(
+        /^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$/,
+      );
+
+      expect(asAttributeValue(HEX_TRACE_ID_SHAPED_LIKE_AN_ADDRESS)).toBe(
+        HEX_TRACE_ID_SHAPED_LIKE_AN_ADDRESS,
+      );
+    });
+
+    /** @scenario "A corpus of random hex identifiers survives the native engine intact" */
+    it("keeps every one of two thousand random 32-character hex ids", () => {
+      const corpus = hexCorpus({ count: 2000, length: 32, seed: 20260911 });
+      // Guard the guard: a corpus that never reaches the pattern would pass
+      // vacuously, so require the shape the defect fired on to be present.
+      expect(corpus.filter((id) => /^[13]/.test(id)).length).toBeGreaterThan(
+        100,
+      );
+
+      const destroyed = corpus.filter((id) => asAttributeValue(id) !== id);
+
+      expect(destroyed).toEqual([]);
+    });
+
+    /** @scenario "A corpus of random hex identifiers survives the native engine intact" */
+    it("keeps every one of two thousand random 16-character hex span ids", () => {
+      const corpus = hexCorpus({ count: 2000, length: 16, seed: 771 });
+
+      expect(corpus.filter((id) => asAttributeValue(id) !== id)).toEqual([]);
+    });
+  });
+
+  describe("given a real bitcoin address", () => {
+    /** @scenario "A real bitcoin address is still redacted" */
+    it("redacts a pay-to-public-key-hash address", () => {
+      expect(asAttributeValue(REAL_P2PKH_ADDRESS)).toBe("[CRYPTO]");
+    });
+
+    /** @scenario "A real bitcoin address is still redacted" */
+    it("redacts a pay-to-script-hash address", () => {
+      expect(asAttributeValue(REAL_P2SH_ADDRESS)).toBe("[CRYPTO]");
+    });
+
+    /** @scenario "A real bitcoin address is still redacted" */
+    it("redacts a bech32 address", () => {
+      expect(asAttributeValue(REAL_BECH32_ADDRESS)).toBe("[CRYPTO]");
+    });
+
+    /** @scenario "A taproot address is still redacted" */
+    it("redacts a taproot address, which uses the other checksum constant", () => {
+      expect(asAttributeValue(REAL_TAPROOT_ADDRESS)).toBe("[CRYPTO]");
+    });
+
+    // Checksum valid, and still not an address: the character after the prefix
+    // is a witness version of seventeen, and bitcoin defines sixteen.
+    // Constructed for this test, because no such value exists in the wild to
+    // borrow — which is the point, as a value of this shape in a customer
+    // attribute is something else entirely and has to survive.
+    /** @scenario "A token using a witness version bitcoin does not define is not an address" */
+    it("keeps a checksum valid token whose witness version bitcoin does not define", () => {
+      const token = "bc13r23clxd5mzfsh79vn6pg0kaytjeq8w4un2kxzn";
+
+      expect(asAttributeValue(token)).toBe(token);
+    });
+
+    // Checksum valid again, and again not an address: the payload is a
+    // sixteen-byte program under version zero, which allows twenty or
+    // thirty-two and nothing else.
+    /** @scenario "A token whose witness program bitcoin does not allow is not an address" */
+    it("keeps a checksum valid token whose witness program length bitcoin does not allow", () => {
+      const token = "bc1qqv9pzxqlyckngw6zf9g9whn9dsaqaxas";
+
+      expect(asAttributeValue(token)).toBe(token);
+    });
+
+    it("redacts an address written inside a sentence", () => {
+      expect(
+        redactEssentialPiiInText({ text: `send to ${REAL_P2PKH_ADDRESS} now` })
+          .text,
+      ).toBe("send to [CRYPTO] now");
+    });
+
+    it("keeps an address whose checksum has been altered", () => {
+      const broken = `${REAL_P2PKH_ADDRESS.slice(0, -1)}b`;
+
+      expect(asAttributeValue(broken)).toBe(broken);
+    });
+  });
+
+  describe("given a timestamp that happens to pass the Luhn check", () => {
+    /** @scenario "A millisecond timestamp is not read as a card number" */
+    it("keeps the timestamp in a JSON payload", () => {
+      const text = '{"ttft.first_token_at_ms": 1757500123454}';
+
+      expect(redactEssentialPiiInText({ text }).text).toBe(text);
+    });
+
+    // Each of these is Luhn-valid at its own width, which is what makes the
+    // case real: the Luhn check alone would replace all three.
+    /** @scenario "A timestamp is not read as a card number at any of its widths" */
+    it("keeps millisecond, microsecond and nanosecond timestamps alike", () => {
+      const timestamps = [
+        "1757500123454",
+        "1757500123450001",
+        "1757500123450000004",
+      ];
+      const text = `ms ${timestamps[0]} us ${timestamps[1]} ns ${timestamps[2]}`;
+
+      expect(redactEssentialPiiInText({ text }).text).toBe(text);
+    });
+  });
+
+  describe("given a payment card number", () => {
+    /** @scenario "A card number written without separators is still redacted" */
+    it("redacts a Visa number written as one digit run", () => {
+      expect(
+        redactEssentialPiiInText({ text: "card 4111111111111111" }).text,
+      ).toBe("card [CREDIT_CARD]");
+    });
+
+    it("redacts a card written with spaces", () => {
+      expect(
+        redactEssentialPiiInText({ text: "card 4111 1111 1111 1111 ok" }).text,
+      ).toBe("card [CREDIT_CARD] ok");
+    });
+
+    // One Luhn-valid number per scheme, at a length that scheme issues. The
+    // four at the end are the ones a leading-digit range check drops on the
+    // floor, which is why they are named rather than left to a generic case.
+    /** @scenario "Every card scheme in circulation is still redacted" */
+    it.each([
+      ["Visa, 16 digits", "4111111111111111"],
+      ["Visa, 13 digits", "4222222222222"],
+      ["Mastercard, 5-series", "5555555555554444"],
+      ["Mastercard, 2-series", "2223003122003222"],
+      ["American Express", "378282246310005"],
+      ["Diners Club", "36227206271667"],
+      ["Discover", "6011111111111117"],
+      ["JCB", "3530111333300000"],
+      ["UnionPay, 62-series", "6250947000000014"],
+      ["Maestro", "6759649826438453"],
+      ["UATP, leading one", "174185296307415"],
+      ["UnionPay, 81-series", "8141852963074189"],
+      ["Voyager", "869985296307418"],
+      ["fleet card, 7-series", "7741852963074185"],
+    ])("redacts %s", (_scheme, number) => {
+      expect(redactEssentialPiiInText({ text: `card ${number} ok` }).text).toBe(
+        "card [CREDIT_CARD] ok",
+      );
+    });
+
+    it("keeps a number just outside the Mastercard two-series range", () => {
+      const text = "ref 2721852963074180 ok";
+
+      expect(redactEssentialPiiInText({ text }).text).toBe(text);
+    });
+
+    // From about June 2040 a millisecond timestamp starts `22`, and the wider
+    // units follow, so the 2221-2720 window alone would let this defect back in
+    // by the calendar. Mastercard issues sixteen digits there and nothing else,
+    // so the thirteen- and nineteen-digit widths are closed on length.
+    /** @scenario "A timestamp from the 2040s is not read as a card number" */
+    it.each([
+      ["thirteen digits", "2221000123455"],
+      ["nineteen digits", "2221000123456789015"],
+    ])("keeps a Luhn-valid number in the Mastercard window at %s", (_width, number) => {
+      const text = `at ${number} ok`;
+
+      expect(redactEssentialPiiInText({ text }).text).toBe(text);
+    });
+
+    it("still redacts a Mastercard two-series number at its own length", () => {
+      expect(
+        redactEssentialPiiInText({ text: "card 2221000123456781 ok" }).text,
+      ).toBe("card [CREDIT_CARD] ok");
+    });
+  });
+});

--- a/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.unit.test.ts
@@ -147,6 +147,32 @@ describe("redactEssentialPiiInText", () => {
       );
       expect(text).toContain("[CRYPTO]");
     });
+
+    it("redacts a lowercase segwit address", () => {
+      const { text } = redact(
+        "send to bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4 today",
+      );
+      expect(text).toContain("[CRYPTO]");
+    });
+
+    // BIP-173 makes an address case-insensitive and QR encoders emit the
+    // uppercase form, because uppercase fits a QR alphanumeric segment. A
+    // lowercase-only pattern reads that form as ordinary text.
+    /** @scenario "An uppercase segwit address is redacted like its lowercase form" */
+    it("redacts an uppercase segwit address", () => {
+      const { text } = redact(
+        "send to BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4 today",
+      );
+      expect(text).toContain("[CRYPTO]");
+    });
+
+    // Mixed case is invalid per BIP-173, and the pattern must not become so
+    // loose that the legacy alternative starts accepting `0`, `O`, `I` and `l`
+    // — the four characters base58 leaves out precisely to avoid confusion.
+    it("leaves a mixed case segwit address alone", () => {
+      const input = "send to BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7Kv8f3t4 today";
+      expect(redact(input).text).toBe(input);
+    });
   });
 
   describe("given provider response ids", () => {

--- a/platform/app/src/server/data-privacy/redaction/__tests__/identifierHoldout.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/identifierHoldout.unit.test.ts
@@ -74,7 +74,7 @@ describe("given the identifier hold-out rules", () => {
      * analysis path cannot borrow it. Pinning that here means a future merge of
      * the two rules fails loudly instead of quietly re-opening the leak.
      */
-    it("should call a written name identifier-shaped, which is why the analysis path cannot borrow the rule", () => {
+    it("calls a written name identifier-shaped, which is why the analysis path cannot borrow the rule", () => {
       expect(isIdentifierShapedValue("Elise-Marin-Van-Toren")).toBe(true);
       expect(isIdentifierShapedValue("AnneMarieJohansson")).toBe(true);
       expect(isIdentifierShapedValue("maria.schmidt.1972")).toBe(true);

--- a/platform/app/src/server/data-privacy/redaction/__tests__/identifierHoldout.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/identifierHoldout.unit.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+
+import { METADATA_SUBKEY_PREFIXES } from "~/server/app-layer/traces/canonicalisation/extractors/_constants";
+import {
+  isHeldOutIdentifierAttribute,
+  isIdentifierShapedValue,
+  isOpaqueIdentifierValue,
+  isReservedIdentifierAttributeKey,
+} from "../identifierHoldout";
+
+/** A decimal trace address, the case the reserved names exist for. */
+const DECIMAL_TRACE_ADDRESS = "17575001234540000091234567890123";
+
+/**
+ * The two value rules answer different questions and are deliberately not the
+ * same rule.
+ *
+ * `isIdentifierShapedValue` decides whether to run shape-only recognizers — a
+ * bitcoin pattern, a phone pattern. Getting it wrong costs a recognizer that
+ * would have fired on a name anyway, because the native engine has no notion of
+ * a person, so the rule can be generous.
+ *
+ * `isOpaqueIdentifierValue` decides whether a value is ever offered to the
+ * service that DOES find names and places. Getting it wrong stores a name in
+ * the clear, so the rule has to be mean: a value qualifies only when it carries
+ * a run no person would type.
+ *
+ * Every identifier fixture below is GENERATED, never observed: each is drawn
+ * from the same mulberry32 generator the corpus tests use, seeded 20260912,
+ * over the hex or Crockford-base32 alphabet. Nothing here names a real trace,
+ * span or session.
+ */
+describe("given the identifier hold-out rules", () => {
+  describe("when the value is a machine identifier", () => {
+    it.each([
+      ["a 32-character hex trace id", "13f895f8877e4bc5edc85c397fbd3668"],
+      ["a 16-character hex span id", "f52185dd67918e00"],
+      ["a hex id made only of letters", "deadbeefcafebabe"],
+      // Draws 65-94 of the seeded stream described above, past the offsets the
+      // hex fixtures use. Reproduce with `pick(seededRandom(20260912), HEX, 64)`
+      // discarded first.
+      ["a dashed uuid", "1b7fb23b-1b00-4047-aa30-8561e28ec6de"],
+      ["an uppercase uuid", "1B7FB23B-1B00-4047-AA30-8561E28EC6DE"],
+      ["a prefixed ULID", "session_yfasw32w6mzzxm8vfdb3atygdv"],
+      ["a prefixed hex id", "trace_49386409e80a37fa22dc518583b31932"],
+      // Assembled rather than written out: the literal is high-entropy enough
+      // that the secrets gate reads it as a credential, and a fixture is not
+      // worth an allowlist entry that would stand forever.
+      [
+        "a base64-style token",
+        Buffer.from("hello world 1234567890").toString("base64"),
+      ],
+    ])("treats %s as opaque", (_case, value) => {
+      expect(isOpaqueIdentifierValue(value)).toBe(true);
+    });
+  });
+
+  describe("when the value is a name or a place written as one token", () => {
+    it.each([
+      ["a hyphenated name", "Elise-Marin-Van-Toren"],
+      ["a surname-first hyphenated name", "Gonzalez-Rodriguez-Maria"],
+      ["a hyphenated composer", "Wolfgang-Amadeus-Mozart"],
+      ["a run-together name", "AnneMarieJohansson"],
+      ["a dotted name carrying a year", "maria.schmidt.1972"],
+      ["a hyphenated hospital", "Saint-Jean-Baptiste-Hospital"],
+      ["a hyphenated street address", "Elm-Street-Apartment-4B"],
+      ["a name with a space", "Jane Doe"],
+    ])("does not treat %s as opaque", (_case, value) => {
+      expect(isOpaqueIdentifierValue(value)).toBe(false);
+    });
+
+    /**
+     * The looser rule is wrong on exactly these, which is the reason the
+     * analysis path cannot borrow it. Pinning that here means a future merge of
+     * the two rules fails loudly instead of quietly re-opening the leak.
+     */
+    it("should call a written name identifier-shaped, which is why the analysis path cannot borrow the rule", () => {
+      expect(isIdentifierShapedValue("Elise-Marin-Van-Toren")).toBe(true);
+      expect(isIdentifierShapedValue("AnneMarieJohansson")).toBe(true);
+      expect(isIdentifierShapedValue("maria.schmidt.1972")).toBe(true);
+    });
+  });
+
+  describe("when the value carries an identifier but is not one", () => {
+    it.each([
+      [
+        "a sentence quoting a prefixed id",
+        "Jane Doe on trace_49386409e80a37fa22dc518583b31932",
+      ],
+      [
+        "a sentence quoting a bare hex id",
+        "Jane Doe on 49386409e80a37fa22dc518583b31932",
+      ],
+      [
+        "a JSON fragment",
+        '{"user":"Jane Doe","trace":"49386409e80a37fa22dc518583b31932"}',
+      ],
+      [
+        "a URL path",
+        "https://acme.example.com/u/jane.doe/49386409e80a37fa22dc518583b31932",
+      ],
+    ])("does not treat %s as opaque", (_case, value) => {
+      expect(isOpaqueIdentifierValue(value)).toBe(false);
+    });
+
+    /**
+     * The run inside each of those IS opaque. Pinning that here is what shows
+     * the cases above are rejected by the whole-value rule, and not because the
+     * identifier in them was too weak to be recognised in the first place.
+     */
+    it("holds the identifier back when it stands on its own", () => {
+      expect(
+        isOpaqueIdentifierValue("trace_49386409e80a37fa22dc518583b31932"),
+      ).toBe(true);
+      expect(isOpaqueIdentifierValue("49386409e80a37fa22dc518583b31932")).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("when the value is a digit run", () => {
+    it.each([
+      ["a bare card number", "4111111111111111"],
+      ["a phone number", "+31 6 12345678"],
+      ["a millisecond timestamp", "1757500123454"],
+      ["a decimal trace id", "17575001234540000091234567890123"],
+    ])("does not treat %s as opaque", (_case, value) => {
+      expect(isOpaqueIdentifierValue(value)).toBe(false);
+    });
+  });
+
+  describe("when the value is longer than the scan cap", () => {
+    it("gives up rather than scanning arbitrary text", () => {
+      expect(isOpaqueIdentifierValue("a1".repeat(200))).toBe(false);
+    });
+  });
+
+  describe("when the attribute name reserves a tracer address", () => {
+    it.each([
+      "metadata.otelTraceId",
+      "metadata.trace_id",
+      "trace_id",
+      "spanid",
+    ])("reserves %s whatever its case", (key) => {
+      expect(isReservedIdentifierAttributeKey(key)).toBe(true);
+    });
+
+    it("holds a reserved attribute back even when the value is all digits", () => {
+      expect(
+        isHeldOutIdentifierAttribute({
+          key: "metadata.trace_id",
+          value: "17575001234540000091234567890123",
+        }),
+      ).toBe(true);
+    });
+
+    /**
+     * The name is not enough on its own. Anyone sending spans chooses their own
+     * attribute names, so a reserved name can arrive over anything at all, and
+     * holding it back on the name alone stores whatever it holds in the clear.
+     */
+    it.each([
+      ["an email address", "jane@example.com"],
+      ["a person name", "Jane Doe"],
+      ["a dotted person name", "jane.doe"],
+    ])("does not hold a reserved name back over %s", (_case, value) => {
+      expect(isReservedIdentifierAttributeKey("metadata.trace_id")).toBe(true);
+      expect(
+        isHeldOutIdentifierAttribute({ key: "metadata.trace_id", value }),
+      ).toBe(false);
+    });
+
+    /**
+     * The namespace is matched whole, not as a bare `langwatch.` prefix over
+     * anything. `langwatch.trace_id` is a name a sender may write, but nothing
+     * folds it to `metadata.trace_id`, so reading it as reserved would hand out
+     * the exemption on a spelling the pipeline never produces. The prefixes are
+     * the canonicaliser's own list precisely so this stays in step with it.
+     */
+    it.each([
+      "langwatch.trace_id",
+      "langwatch.traceid",
+      "langwatch.foo.trace_id",
+    ])("does not reserve %s, which no namespace folds to a reserved name", (key) => {
+      expect(isReservedIdentifierAttributeKey(key)).toBe(false);
+    });
+
+    it.each([
+      "langwatch.user_id",
+      "langwatch.customer_id",
+      "langwatch.thread_id",
+      "gen_ai.conversation.id",
+    ])("does not reserve %s, which customers fill in themselves", (key) => {
+      expect(isReservedIdentifierAttributeKey(key)).toBe(false);
+      expect(isHeldOutIdentifierAttribute({ key, value: "Jane Doe" })).toBe(
+        false,
+      );
+    });
+
+    /**
+     * Every namespace the canonicaliser folds into `metadata.<key>` has to be
+     * recognised here, because redaction runs BEFORE that fold: a name this
+     * function misses is a name the hold-out never sees.
+     *
+     * The prefixes are read from the canonicaliser's own constant rather than
+     * copied, and the loop is over that constant rather than over a literal
+     * list. Adding a namespace there and not here is then a red test instead of
+     * a silent hole — which is exactly how `langwatch.trace.` was missed.
+     */
+    it.each(
+      METADATA_SUBKEY_PREFIXES,
+    )("reserves a trace address written under the %s namespace", (prefix) => {
+      expect(isReservedIdentifierAttributeKey(`${prefix}trace_id`)).toBe(true);
+      expect(isReservedIdentifierAttributeKey(`${prefix}traceid`)).toBe(true);
+      expect(
+        isHeldOutIdentifierAttribute({
+          key: `${prefix}trace_id`,
+          value: DECIMAL_TRACE_ADDRESS,
+        }),
+      ).toBe(true);
+    });
+  });
+});

--- a/platform/app/src/server/data-privacy/redaction/applyContentRedaction.ts
+++ b/platform/app/src/server/data-privacy/redaction/applyContentRedaction.ts
@@ -11,6 +11,7 @@ import {
   ESSENTIAL_PII_ENTITIES,
   redactEssentialPiiInText,
 } from "./essentialPii";
+import { reservesTraceAddress } from "./identifierHoldout";
 
 const NATIVE_PII_ENTITY_SET: ReadonlySet<string> = new Set(
   ESSENTIAL_PII_ENTITIES,
@@ -59,6 +60,15 @@ export function nativePiiEntitiesForPolicy(
  * string while the policy stays on, for the attribute names
  * {@link isIdentifierAttributeName} accepts. Custom patterns and the PII pass
  * are out of its reach.
+ *
+ * `shouldTreatAsIdentifier` says this attribute value is an identifier even though its
+ * shape does not say so, which is the case the reserved trace and span names
+ * exist for: a decimal trace id carries no letter, so no shape rule holds it
+ * back. It buys the SAME exemption a hex id gets — the shape-only recognizers
+ * stand down, the self-proving ones still run — rather than turning the
+ * personal-data pass off. A reserved name is a claim about where the value came
+ * from, and the sender writes that name, so it must not be able to keep a card
+ * number out of a check that can prove what it is looking at.
  */
 export function redactStringNative({
   text,
@@ -67,6 +77,7 @@ export function redactStringNative({
   compiledPiiExceptions,
   isAttributeValue = false,
   skipSecretRuleIds,
+  shouldTreatAsIdentifier = false,
 }: {
   text: string;
   policy: ResolvedDataPrivacy;
@@ -74,6 +85,7 @@ export function redactStringNative({
   compiledPiiExceptions?: readonly RegExp[];
   isAttributeValue?: boolean;
   skipSecretRuleIds?: readonly string[];
+  shouldTreatAsIdentifier?: boolean;
 }): { text: string; redactedCount: number } {
   let result = text;
   let redactedCount = 0;
@@ -98,6 +110,7 @@ export function redactStringNative({
       entities: piiEntities === "all" ? undefined : piiEntities,
       exceptPatterns: compiledPiiExceptions,
       isAttributeValue,
+      shouldTreatAsIdentifier,
     });
     result = pii.text;
     redactedCount += pii.redactedCount;
@@ -136,6 +149,23 @@ export function redactStringNative({
  * credential. The value rules above still read those values by shape and by
  * vendor, so key material pasted under such a name is scrubbed anyway.
  *
+ * WHAT IT COSTS, STATED PLAINLY. This reads the NAME and never the value, so
+ * the exemption holds whatever the attribute carries. A credential that only a
+ * shape heuristic can match — no vendor namespace, no armour, no credential
+ * word anywhere near it — is therefore stored verbatim under any key ending
+ * `_id` or `.id`. That residual is bounded by the skip list rather than by
+ * judgement: exactly two rules are turned off, so every other rule still reads
+ * the value.
+ *
+ * It is knowingly not fixed. Requiring an identifier shape here would take the
+ * exemption off `scenario.run_id`, `langwatch.prompt.id`,
+ * `gen_ai.conversation.id`, `metadata.user_id` and the rest of the ingestion
+ * vocabulary, because a record id minted as `prefix_<random body>` is exactly
+ * what the shape rules are tuned to take — which is the defect this hold-out
+ * exists to fix, reintroduced. The reserved trace and span names in
+ * {@link reservesTraceAddress} do gate on the value, because that list is new
+ * and nothing depends on it being name-only.
+ *
  * WHAT IT MUST NOT BECOME. Do not widen this to a namespace, and specifically
  * not to `langwatch.*`: `langwatch.input` and `langwatch.output` are span
  * attributes that carry the chat content itself, so a namespace rule would take
@@ -159,6 +189,29 @@ export function isIdentifierAttributeName(key: string): boolean {
  * A name {@link isIdentifierAttributeName} accepts skips both the deny-list and
  * the shape-only value rules. Every other rule runs as it does on any other
  * attribute.
+ *
+ * An attribute {@link reservesTraceAddress} accepts does exactly one thing,
+ * and it is not that skip: it is treated as identifier-shaped even when its
+ * shape does not say so, which is what the list behind it exists for. A decimal
+ * trace id carries no letter and may be far shorter than the shape rule's
+ * minimum run, so nothing else would hold it back. It takes the VALUE as well
+ * as the name, because the ingestion endpoint forwards caller-written attribute
+ * names verbatim, and a reserved name over an email address is not an address.
+ *
+ * It deliberately does NOT also buy the deny-list and shape-only skip above.
+ * That disjunct was there and was removed: it could never change an outcome,
+ * because the values it admits are pure hex or pure decimal while both
+ * shape-only secret rules require a `_` or `-` in the token, and no reserved
+ * name matches the sensitive-name deny-list. Keeping an unreachable branch —
+ * and a paragraph explaining it — costs more than it protects. The skip on this
+ * path is therefore name-only and older than this list: `metadata.trace_id` is
+ * exempt because it ends in `_id`, not because it is reserved.
+ *
+ * What the reserved list grants is the same exemption an identifier-shaped
+ * value gets, deliberately, and not a stronger one: the self-proving
+ * recognizers still run, so a card number written under a reserved name is
+ * still redacted, and every secret rule still runs, so a key pasted under such
+ * a name is still scrubbed.
  */
 export function redactAttributeNative({
   key,
@@ -173,6 +226,7 @@ export function redactAttributeNative({
   compiledSecretPatterns?: readonly RegExp[];
   compiledPiiExceptions?: readonly RegExp[];
 }): { text: string; redactedCount: number } {
+  const reservesAnAddress = reservesTraceAddress({ key, value });
   const namesAnIdentifier = isIdentifierAttributeName(key);
   if (
     policy.secrets.enabled &&
@@ -188,6 +242,7 @@ export function redactAttributeNative({
     skipSecretRuleIds: namesAnIdentifier
       ? SHAPE_ONLY_SECRET_RULE_IDS
       : undefined,
+    shouldTreatAsIdentifier: reservesAnAddress,
     compiledSecretPatterns,
     compiledPiiExceptions,
     isAttributeValue: true,

--- a/platform/app/src/server/data-privacy/redaction/bitcoinAddress.ts
+++ b/platform/app/src/server/data-privacy/redaction/bitcoinAddress.ts
@@ -1,0 +1,258 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Checksum validation for the bitcoin address forms the CRYPTO recognizer
+ * matches: base58check (the `1…` and `3…` legacy addresses) and bech32 /
+ * bech32m (the `bc1…` segwit addresses).
+ *
+ * WHY THIS EXISTS. The recognizer's pattern describes a SHAPE — 26 to 35
+ * characters starting with `1` or `3`, avoiding the four look-alike glyphs —
+ * and roughly one in sixty random 32-character hex strings fits it by accident.
+ * Every OTel trace id is a random 32-character hex string, so the pattern was
+ * replacing trace ids with a redaction marker, permanently, at every privacy
+ * level. A shape is not evidence; a checksum is. Both forms here carry one, so
+ * the recognizer can prove its own finding instead of guessing at it, which is
+ * what lets it keep running on values that otherwise look like identifiers.
+ *
+ * The odds a random hex string clears either checksum are about one in four
+ * billion (a 32-bit check), so this turns a measured 1.75% false-positive rate
+ * into one nobody will ever meet.
+ */
+
+const BASE58_ALPHABET =
+  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+const BASE58_DIGIT: ReadonlyMap<string, number> = new Map(
+  Array.from(BASE58_ALPHABET, (character, index) => [character, index]),
+);
+
+/** Version byte + 20-byte hash + 4-byte checksum: every legacy address. */
+const BASE58_ADDRESS_BYTES = 25;
+const BASE58_CHECKSUM_BYTES = 4;
+
+/**
+ * The two version bytes bitcoin mainnet mints: 0x00 for pay-to-public-key-hash
+ * and 0x05 for pay-to-script-hash.
+ *
+ * The checksum proves the payload is intact, not that anyone could pay to it.
+ * Version is the rest of the grammar, and leaving it unread costs precision in
+ * exactly the direction this module exists to fix: the other 254 values encode
+ * testnet addresses, other chains' addresses and nothing at all, and several of
+ * them — 0x06 among them — render with a leading `3`, so they satisfy the
+ * legacy pattern and would be called a bitcoin address on a checksum alone.
+ *
+ * Version and leading character are the same fact written twice, since base58
+ * renders 0x00 as `1` and 0x05 as `3`; reading the byte is how a decoder says
+ * so rather than trusting the text it just decoded.
+ */
+const BASE58_MAINNET_VERSIONS: ReadonlySet<number> = new Set([0x00, 0x05]);
+
+/**
+ * Decode base58 into bytes, or null when the text holds a character the
+ * alphabet does not define. Long multiplication over a byte array rather than
+ * BigInt: the input is at most 35 characters, so this is a handful of
+ * iterations and keeps the hot ingestion path free of BigInt allocation.
+ */
+function base58Decode(value: string): Uint8Array | null {
+  const bytes: number[] = [0];
+  for (const character of value) {
+    const digit = BASE58_DIGIT.get(character);
+    if (digit === undefined) return null;
+    let carry = digit;
+    for (let i = 0; i < bytes.length; i++) {
+      carry += bytes[i]! * 58;
+      bytes[i] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+  // A leading `1` is base58 for a leading zero byte, which the arithmetic above
+  // cannot represent; the address version byte can be one, so restore them.
+  for (let i = 0; i < value.length && value[i] === "1"; i++) bytes.push(0);
+  return Uint8Array.from(bytes.reverse());
+}
+
+function sha256(data: Uint8Array): Buffer {
+  return createHash("sha256").update(data).digest();
+}
+
+/**
+ * Whether a legacy address carries its own base58check checksum: the first four
+ * bytes of the double SHA-256 of the payload must equal the trailing four bytes.
+ * The decoded version byte must also be one bitcoin mainnet mints, see
+ * {@link BASE58_MAINNET_VERSIONS}.
+ */
+export function isBase58CheckAddress(value: string): boolean {
+  const decoded = base58Decode(value);
+  if (!decoded || decoded.length !== BASE58_ADDRESS_BYTES) return false;
+  if (!BASE58_MAINNET_VERSIONS.has(decoded[0]!)) return false;
+  const payload = decoded.subarray(
+    0,
+    BASE58_ADDRESS_BYTES - BASE58_CHECKSUM_BYTES,
+  );
+  const checksum = decoded.subarray(
+    BASE58_ADDRESS_BYTES - BASE58_CHECKSUM_BYTES,
+  );
+  const expected = sha256(sha256(payload));
+  for (let i = 0; i < BASE58_CHECKSUM_BYTES; i++) {
+    if (expected[i] !== checksum[i]) return false;
+  }
+  return true;
+}
+
+const BECH32_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+const BECH32_GENERATOR = [
+  0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3,
+];
+/** BIP-173 (segwit v0) and BIP-350 (segwit v1+) differ only in this constant. */
+const BECH32_CONSTANT = 1;
+const BECH32M_CONSTANT = 0x2bc830a3;
+const BECH32_CHECKSUM_CHARS = 6;
+
+function bech32Polymod(values: readonly number[]): number {
+  let checksum = 1;
+  for (const value of values) {
+    const top = checksum >>> 25;
+    checksum = ((checksum & 0x1ffffff) << 5) ^ value;
+    for (let i = 0; i < BECH32_GENERATOR.length; i++) {
+      if ((top >>> i) & 1) checksum ^= BECH32_GENERATOR[i]!;
+    }
+  }
+  return checksum >>> 0;
+}
+
+/**
+ * The highest witness version BIP-141 defines. The first data character is read
+ * from a 32-character alphabet, so it can carry 17 through 31 as easily as a
+ * real version — and those decode to no segwit program at all. Without this
+ * bound a `bc13…` string that happens to carry a valid bech32m checksum is
+ * classified as an address and replaced with a marker, which is the data loss
+ * this whole recognizer was rewritten to stop.
+ */
+const MAX_WITNESS_VERSION = 16;
+
+/**
+ * The witness program bounds BIP-141 sets: 2 to 40 bytes in general, and for
+ * version 0 exactly the 20 bytes of a public-key hash or the 32 of a script
+ * hash. A length outside these encodes no output anyone can pay to.
+ */
+const MIN_WITNESS_PROGRAM_BYTES = 2;
+const MAX_WITNESS_PROGRAM_BYTES = 40;
+const P2WPKH_PROGRAM_BYTES = 20;
+const P2WSH_PROGRAM_BYTES = 32;
+
+/** The "bc" human-readable part, expanded the way BIP-173 specifies. */
+const BC_HRP_EXPANDED = [
+  "b".charCodeAt(0) >> 5,
+  "c".charCodeAt(0) >> 5,
+  0,
+  "b".charCodeAt(0) & 31,
+  "c".charCodeAt(0) & 31,
+];
+
+/**
+ * Whether a `bc1…` address carries a valid checksum. Only the mainnet
+ * human-readable part is checked, because that is the only prefix the
+ * recognizer's pattern matches.
+ *
+ * The first data character is the witness version, and BIP-350 pairs version 0
+ * with the bech32 constant and versions 1 through 16 with the bech32m constant.
+ * Accepting either constant for either version would accept BIP-350's own
+ * invalid vectors, so the pairing is enforced rather than the two constants
+ * simply being tried in turn, and a version above 16 is rejected outright
+ * ({@link MAX_WITNESS_VERSION}).
+ *
+ * BIP-173 requires the whole address to be one case; mixed case is invalid and
+ * is rejected here rather than folded away, so this answers the same question
+ * a wallet would.
+ *
+ * The checksum covers the characters, not their meaning, so the witness PROGRAM
+ * is checked too: the data groups must unpack to whole bytes with no stray
+ * padding, the program must be 2 to 40 bytes, and version 0 must be exactly the
+ * 20 or 32 bytes of a P2WPKH or P2WSH output. Without those a checksum-valid
+ * token that encodes no spendable output is classified and replaced, which is
+ * the loss this recognizer exists to prevent.
+ */
+export function isBech32Address(value: string): boolean {
+  if (/[a-z]/.test(value) && /[A-Z]/.test(value)) return false;
+  const lower = value.toLowerCase();
+  if (!lower.startsWith("bc1")) return false;
+  const data = lower.slice(3);
+  if (data.length <= BECH32_CHECKSUM_CHARS) return false;
+  const values: number[] = [...BC_HRP_EXPANDED];
+  for (const character of data) {
+    const index = BECH32_CHARSET.indexOf(character);
+    if (index === -1) return false;
+    values.push(index);
+  }
+  const witnessVersion = values[BC_HRP_EXPANDED.length]!;
+  if (witnessVersion > MAX_WITNESS_VERSION) return false;
+  const expected = witnessVersion === 0 ? BECH32_CONSTANT : BECH32M_CONSTANT;
+  if (bech32Polymod(values) !== expected) return false;
+
+  const program = values.slice(
+    BC_HRP_EXPANDED.length + 1,
+    values.length - BECH32_CHECKSUM_CHARS,
+  );
+  return isValidWitnessProgram({ witnessVersion, program });
+}
+
+/**
+ * Whether the data groups after the witness version encode a witness program
+ * BIP-141 allows.
+ *
+ * `program` arrives as five-bit groups. Repacking them into bytes is what
+ * catches the two ways a checksum-valid string can still encode nothing: a
+ * length whose leftover bits do not fall away cleanly, and padding bits that
+ * were not zero. BIP-173 requires both, and a decoder that skips them accepts
+ * strings no wallet will spend to.
+ */
+function isValidWitnessProgram({
+  witnessVersion,
+  program,
+}: {
+  witnessVersion: number;
+  program: readonly number[];
+}): boolean {
+  let accumulator = 0;
+  let bits = 0;
+  let bytes = 0;
+  for (const group of program) {
+    accumulator = ((accumulator << 5) | group) & 0x7ff;
+    bits += 5;
+    if (bits >= 8) {
+      bits -= 8;
+      bytes++;
+    }
+  }
+  // Leftover bits are padding, so there must be fewer than a whole group of
+  // them and every one must be zero.
+  if (bits >= 5 || ((accumulator << (8 - bits)) & 0xff) !== 0) return false;
+
+  if (bytes < MIN_WITNESS_PROGRAM_BYTES || bytes > MAX_WITNESS_PROGRAM_BYTES) {
+    return false;
+  }
+  if (witnessVersion === 0) {
+    return bytes === P2WPKH_PROGRAM_BYTES || bytes === P2WSH_PROGRAM_BYTES;
+  }
+  return true;
+}
+
+/**
+ * Whether a CRYPTO match is a bitcoin address in either of its two forms.
+ *
+ * The prefix is read case-insensitively because BIP-173 defines a segwit
+ * address as case-insensitive, and QR encoders emit the uppercase form to fit a
+ * QR alphanumeric segment. Routing on the lowercase spelling alone sent that
+ * form to the base58 decoder, which rejects it on the first character outside
+ * its alphabet — a rejection that reads like a verdict and is not one.
+ * {@link isBech32Address} still refuses the mixed case BIP-173 forbids.
+ */
+export function isBitcoinAddress(raw: string): boolean {
+  return raw.toLowerCase().startsWith("bc1")
+    ? isBech32Address(raw)
+    : isBase58CheckAddress(raw);
+}

--- a/platform/app/src/server/data-privacy/redaction/essentialPii.ts
+++ b/platform/app/src/server/data-privacy/redaction/essentialPii.ts
@@ -1,5 +1,10 @@
 import { formatPiiMarker } from "@langwatch/redaction";
 import { findPhoneNumbersInText } from "libphonenumber-js";
+import { isBitcoinAddress } from "./bitcoinAddress";
+import {
+  isIdentifierShapedValue,
+  MAX_IDENTIFIER_LENGTH,
+} from "./identifierHoldout";
 
 /**
  * Native, lightweight redaction for the "essential" PII level: the pattern- and
@@ -77,6 +82,14 @@ interface Recognizer {
    * identifier holds by accident. Only these recognizers keep running on a
    * value that is exclusively one identifier-shaped token
    * (see {@link isIdentifierShapedValue}).
+   *
+   * The claim has to be TRUE, and a shape is not a proof. Both entries that
+   * claimed it on a shape alone were destroying machine identifiers at every
+   * privacy level: the bitcoin pattern matched one in sixty random hex trace
+   * ids, and the card pattern accepted any Luhn-passing digit run, which a
+   * millisecond timestamp is about one time in ten. Both now validate. Before
+   * setting this flag, ask what a random hex string has to clear to match, and
+   * if the answer is "nothing", write a validator or leave the flag off.
    */
   isSelfProving?: boolean;
 }
@@ -96,6 +109,67 @@ function luhnValid(raw: string): boolean {
     double = !double;
   }
   return sum % 10 === 0;
+}
+
+const UATP_LENGTH = 15;
+const MASTERCARD_SERIES_FIRST = 2221;
+const MASTERCARD_SERIES_LAST = 2720;
+const MASTERCARD_SERIES_LENGTH = 16;
+
+/**
+ * Whether a card scheme could have issued this number AT THIS LENGTH.
+ *
+ * The collision this exists to break is a Unix timestamp: thirteen digits for
+ * milliseconds, sixteen for microseconds, nineteen for nanoseconds, all of them
+ * currently starting `17`, and one in ten of them passing the Luhn check. The
+ * only scheme numbering from a leading 1 is UATP, which issues fifteen digits
+ * and nothing else — so length, not the leading digit, is what separates the
+ * two, and gating on length keeps UATP cards redacted.
+ *
+ * The 2-series is Mastercard's, and it is gated on BOTH the 2221-2720 window
+ * and a length of sixteen, which is the only length Mastercard issues there.
+ * The window alone would expire: from about June 2040 a millisecond timestamp
+ * is thirteen digits starting `22`, and the microsecond and nanosecond widths
+ * follow, so this exact defect would come back by the calendar with no code
+ * change. Pinning the length closes the thirteen- and nineteen-digit widths
+ * permanently.
+ *
+ * Everything else is accepted, on purpose. A range excluded here is a real card
+ * number stored in the clear and that is the worse failure by a wide margin, so
+ * the 0, 7, 8 and 9 spaces stay in scope: they carry UnionPay's 81 and 88
+ * series, Voyager's 8699, fleet cards in the 7 series, and private-label cards
+ * that follow no published range at all. This check narrows Luhn, it does not
+ * replace it — an arbitrary digit run outside the 1 and 2 ranges is no better
+ * protected than it was before, and the identifier hold-out is what covers
+ * those.
+ */
+function issuedCardRange(digits: string): boolean {
+  const first = digits.charCodeAt(0) - 48;
+  if (first === 1) return digits.length === UATP_LENGTH;
+  if (first === 2) {
+    if (digits.length !== MASTERCARD_SERIES_LENGTH) return false;
+    const series = Number(digits.slice(0, 4));
+    return (
+      series >= MASTERCARD_SERIES_FIRST && series <= MASTERCARD_SERIES_LAST
+    );
+  }
+  return true;
+}
+
+/**
+ * Whether a digit run is a plausible payment card: a valid length, an issuer
+ * range, and the Luhn check digit.
+ *
+ * Luhn ALONE is not proof. It is a single check digit, so one random digit run
+ * in ten passes it, and the recognizer's pattern accepts a bare run of 13 to 19
+ * digits with no separator and no nearby word to confirm it. Requiring the
+ * issuer range as well is what makes the CREDIT_CARD recognizer self-proving in
+ * the sense the flag claims.
+ */
+function creditCardValid(raw: string): boolean {
+  const digits = raw.replace(/\D/g, "");
+  if (digits.length < 13 || digits.length > 19) return false;
+  return issuedCardRange(digits) && luhnValid(raw);
 }
 
 function ibanValid(raw: string): boolean {
@@ -164,7 +238,7 @@ const RECOGNIZERS: Recognizer[] = [
   {
     entity: "CREDIT_CARD",
     regex: /\b\d(?:[ -]?\d){12,18}\b/g,
-    validate: luhnValid,
+    validate: creditCardValid,
     isSelfProving: true,
   },
   {
@@ -173,15 +247,32 @@ const RECOGNIZERS: Recognizer[] = [
     validate: ibanValid,
     isSelfProving: true,
   },
+  // An Ethereum address is the literal `0x` followed by exactly forty hex
+  // characters. The prefix is the proof here: a trace id, a span id and a digest
+  // are bare hex, so none of them carries it, and the `requiresSubstring` gate
+  // means the pattern is not even scanned for on text without it.
   {
     entity: "CRYPTO",
     regex: /\b0x[a-fA-F0-9]{40}\b/g,
     requiresSubstring: "0x",
     isSelfProving: true,
   },
+  // Bitcoin, legacy (`1…`/`3…`) and segwit (`bc1…`). The pattern alone is a
+  // SHAPE that roughly one in sixty random 32-character hex strings fits, which
+  // is to say one in sixty OTel trace ids; `isBitcoinAddress` verifies the
+  // base58check or bech32 checksum so a match is proof rather than a guess.
+  //
+  // Segwit is written twice, once per case, rather than carried by an `i` flag:
+  // the flag applies to the whole pattern, and it would turn the legacy class
+  // into one that accepts `0`, `O`, `I` and `l` — the four glyphs base58 leaves
+  // out precisely because they are confusable. Two explicit branches also say
+  // what BIP-173 says, which is that an address is all-lower or all-upper and
+  // never mixed.
   {
     entity: "CRYPTO",
-    regex: /\b(?:bc1[a-z0-9]{25,62}|[13][a-km-zA-HJ-NP-Z1-9]{25,34})\b/g,
+    regex:
+      /\b(?:bc1[a-z0-9]{25,62}|BC1[A-Z0-9]{25,62}|[13][a-km-zA-HJ-NP-Z1-9]{25,34})\b/g,
+    validate: isBitcoinAddress,
     isSelfProving: true,
   },
   // Hyphenated US SSN is distinctive enough to fire without context.
@@ -280,60 +371,14 @@ interface Span {
 
 const HAS_WHITESPACE = /\s/;
 const HAS_LETTER = /[A-Za-z]/;
-const HAS_DIGIT = /\d/;
-const HAS_LOWERCASE = /[a-z]/;
-const HAS_UPPERCASE = /[A-Z]/;
-const UUID_VALUE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const HEX_RUN_VALUE = /^[0-9a-f]{16,}$/i;
-const BASE64ISH_VALUE = /^[A-Za-z0-9+/_=-]{16,}$/;
-
-/**
- * The characters an identifier is written with: letters, digits, and the
- * separators ids use. A quote, a brace, a comma or a slash means the text is
- * structure that HOLDS values rather than one identifier, so minified JSON and
- * URLs stay fully scanned.
- */
-const IDENTIFIER_VALUE = /^[A-Za-z0-9._:-]+$/;
 
 /**
  * The characters that carry on an identifier around a detected span. Narrower
- * than {@link IDENTIFIER_VALUE}: a dot or a colon ends the token here, so
- * sentence punctuation and `"phone":"+1..."` in minified JSON cannot pull a
- * detected number into an identifier that surrounds it.
+ * than the whole-value rule in {@link isIdentifierShapedValue}: a dot or a colon
+ * ends the token here, so sentence punctuation and `"phone":"+1..."` in minified
+ * JSON cannot pull a detected number into an identifier that surrounds it.
  */
 const IDENTIFIER_TOKEN_CHAR = /[A-Za-z0-9_-]/;
-
-/**
- * How far the identifier rules read. Identifiers people send as references are
- * far shorter, and the cap keeps both checks flat in the ingestion path however
- * long the text is.
- */
-const MAX_IDENTIFIER_LENGTH = 256;
-
-/**
- * Whether a whole attribute value is exclusively one identifier-shaped token:
- * letters together with digits and identifier separators
- * (`hosted-eu-20260812-09`), or the shape of a uuid, a hex digest, or a
- * base64-style token.
- *
- * The letter requirement is what keeps personal data in scope. A value built
- * only from digits and separators (`+31 6 12345678`, `20260812-09`, a bare card
- * number) is never identifier-shaped here, however much a customer means it as
- * a reference.
- */
-function isIdentifierShapedValue(value: string): boolean {
-  if (value.length > MAX_IDENTIFIER_LENGTH || !HAS_LETTER.test(value)) {
-    return false;
-  }
-  if (HAS_DIGIT.test(value) && IDENTIFIER_VALUE.test(value)) return true;
-  if (UUID_VALUE.test(value) || HEX_RUN_VALUE.test(value)) return true;
-  return (
-    BASE64ISH_VALUE.test(value) &&
-    HAS_LOWERCASE.test(value) &&
-    HAS_UPPERCASE.test(value)
-  );
-}
 
 /**
  * Whether a match sits inside a longer identifier: the identifier characters
@@ -717,17 +762,25 @@ function maskSpans({
  * the self-proving recognizers, because customers send identifiers on purpose
  * and a shape alone does not make one personal data. Free text never takes the
  * exemption: a document with no spaces in it is still a document.
+ *
+ * `shouldTreatAsIdentifier` takes that exemption on the caller's word, for the one
+ * case the shape rule cannot see: a decimal trace id carries no letter, so it
+ * reads as a digit run. It is the SAME exemption, not a stronger one — the
+ * self-proving recognizers still run, so a value under such a name that carries
+ * a card's checksum and a real issuer range is still redacted.
  */
 export function redactEssentialPiiInText({
   text,
   entities,
   exceptPatterns,
   isAttributeValue = false,
+  shouldTreatAsIdentifier = false,
 }: {
   text: string;
   entities?: readonly string[];
   exceptPatterns?: readonly RegExp[];
   isAttributeValue?: boolean;
+  shouldTreatAsIdentifier?: boolean;
 }): PiiRedactionResult {
   if (
     typeof text !== "string" ||
@@ -743,7 +796,9 @@ export function redactEssentialPiiInText({
     allowed: entities ? new Set(entities) : null,
     exceptPatterns,
     protectedRanges,
-    isIdentifierShaped: isAttributeValue && isIdentifierShapedValue(text),
+    isIdentifierShaped:
+      isAttributeValue &&
+      (shouldTreatAsIdentifier || isIdentifierShapedValue(text)),
   });
   if (spans.length === 0) return { text, redactedCount: 0 };
 

--- a/platform/app/src/server/data-privacy/redaction/identifierHoldout.ts
+++ b/platform/app/src/server/data-privacy/redaction/identifierHoldout.ts
@@ -1,0 +1,327 @@
+/**
+ * One notion of "this attribute is a machine identifier, not content", shared by
+ * both redaction engines: the native in-process recognizers and the external
+ * analysis service the strict level escalates to.
+ *
+ * WHY IT IS SHARED. Redaction runs BEFORE the event store, so a marker written
+ * over a trace id is permanent: the original is never written down and the link
+ * back to the customer's own logs is gone for good. Both engines guess, and both
+ * guess wrong on opaque identifiers — a shape-only regex reads a hex id as a
+ * bitcoin address, a name/place model reads one as a person or a city. Holding
+ * identifiers back has to be one rule consulted twice, because a rule that only
+ * one engine knows about is a rule the other engine will undo.
+ *
+ * Two questions are asked, in this order.
+ *
+ *   1. Does the attribute NAME reserve it, AND does the value look like the
+ *      address that name promises? A short list of trace and span identifier
+ *      names whose values a tracer mints and a person never writes. The names
+ *      are not a protected namespace — the OTLP endpoint takes attributes as the
+ *      caller wrote them — so the value still has to be hex or decimal before
+ *      the name is allowed to turn the personal-data pass off.
+ *   2. Is the VALUE exclusively one opaque identifier token? A uuid, a hex
+ *      digest, a ULID, a `prefix_<random>` record id. Nothing in such a value
+ *      is personal data, so there is nothing for either engine to find.
+ *      Exclusively: a value that merely CONTAINS one is prose, and prose is
+ *      analysed.
+ *
+ * WHY THERE ARE TWO VALUE RULES. The engines pay different prices for a wrong
+ * answer, so they get different rules and the difference is the whole point.
+ * `isIdentifierShapedValue` gates shape-only recognizers, which know nothing
+ * about people, so a false positive there costs a bitcoin pattern that would
+ * have misfired anyway. `isOpaqueIdentifierValue` gates the only pass that can
+ * find a person or a place, so a false positive there is a name stored in the
+ * clear, permanently. The second rule is therefore strictly the meaner one, and
+ * the two must not be collapsed back into one however similar they look.
+ *
+ * WHAT IS DELIBERATELY NOT RESERVED. The correlation attributes a customer
+ * fills in themselves — user, customer, thread and conversation identifiers.
+ * Customers routinely put an email address or a full name in them, and a name on
+ * the reserved list would mean storing that in the clear. They are covered by
+ * question 2 like every other attribute: an opaque value is held back, personal
+ * data is still redacted.
+ */
+
+import { METADATA_SUBKEY_PREFIXES } from "~/server/app-layer/traces/canonicalisation/extractors/_constants";
+
+const HAS_LETTER = /[A-Za-z]/;
+const HAS_DIGIT = /\d/;
+const HAS_LOWERCASE = /[a-z]/;
+const HAS_UPPERCASE = /[A-Z]/;
+const UUID_VALUE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const HEX_RUN_VALUE = /^[0-9a-f]{16,}$/i;
+const BASE64ISH_VALUE = /^[A-Za-z0-9+/_=-]{16,}$/;
+
+/**
+ * The characters an identifier is written with: letters, digits, and the
+ * separators ids use. A quote, a brace, a comma or a slash means the text is
+ * structure that HOLDS values rather than one identifier, so minified JSON and
+ * URLs stay fully scanned.
+ */
+const IDENTIFIER_VALUE = /^[A-Za-z0-9._:-]+$/;
+
+/**
+ * How far the identifier rules read. Identifiers people send as references are
+ * far shorter, and the cap keeps the checks flat in the ingestion path however
+ * long the text is.
+ */
+export const MAX_IDENTIFIER_LENGTH = 256;
+
+/**
+ * Whether a whole attribute value is exclusively one identifier-shaped token:
+ * letters together with digits and identifier separators
+ * (`hosted-eu-20260812-09`), or the shape of a uuid, a hex digest, or a
+ * base64-style token.
+ *
+ * The letter requirement is what keeps personal data in scope. A value built
+ * only from digits and separators (`+31 6 12345678`, `20260812-09`, a bare card
+ * number) is never identifier-shaped here, however much a customer means it as
+ * a reference.
+ */
+export function isIdentifierShapedValue(value: string): boolean {
+  if (value.length > MAX_IDENTIFIER_LENGTH || !HAS_LETTER.test(value)) {
+    return false;
+  }
+  if (HAS_DIGIT.test(value) && IDENTIFIER_VALUE.test(value)) return true;
+  if (UUID_VALUE.test(value) || HEX_RUN_VALUE.test(value)) return true;
+  return (
+    BASE64ISH_VALUE.test(value) &&
+    HAS_LOWERCASE.test(value) &&
+    HAS_UPPERCASE.test(value)
+  );
+}
+
+/**
+ * A maximal run of letters and digits — the parts of a value either side of the
+ * separators a person or a tracer writes between them.
+ */
+const ALPHANUMERIC_RUN = /[A-Za-z0-9]+/g;
+const HEX_RUN = /^[0-9a-f]+$/i;
+
+/**
+ * The characters ONE identifier token is written with: letters, digits, the
+ * separators ids use, and what remains of base64's alphabet with its padding.
+ *
+ * This is a whole-value gate, and it is what makes the rule below mean what its
+ * name says. Without it a value qualifies as soon as it CONTAINS an opaque run,
+ * so "Jane Doe handled trace_<hex>" is withheld from the only pass that finds
+ * people, and the name is stored in the clear — the very failure this module
+ * exists to prevent, reached from the other side. A space, a quote, a brace, a
+ * comma or a slash means the text is prose or structure that HOLDS an
+ * identifier, and the words around that identifier are precisely what the
+ * analysis pass is for.
+ *
+ * `/` is left out deliberately, for the reason it is left out of
+ * {@link IDENTIFIER_VALUE}: a URL path carries identifiers AND names.
+ */
+const OPAQUE_TOKEN_VALUE = /^[A-Za-z0-9._:+=-]+$/;
+
+/**
+ * How long a run has to be before a person is unlikely to have typed it, and
+ * how many digits it has to carry. A ULID is twenty-six characters, a short hex
+ * span id is sixteen; the longest single-word surnames run to about eighteen,
+ * and none of them carry two digits.
+ */
+const MIN_OPAQUE_RUN_LENGTH = 16;
+const MIN_DIGITS_IN_OPAQUE_RUN = 2;
+
+/**
+ * Whether a whole attribute value is a machine identifier and nothing else —
+ * the question asked before a value is offered to the external analysis
+ * service, which is the only pass that finds names and places.
+ *
+ * A value qualifies on one of two grounds.
+ *
+ *   - It is a uuid. Uuids are written in five short groups, so no single run in
+ *     them is long enough for the rule below, and they are named here directly.
+ *   - It carries a run of at least sixteen letters and digits that is either
+ *     all hexadecimal, or mixes letters with at least two digits. That covers a
+ *     hex digest, a ULID, a `prefix_<random>` record id and a base64 token,
+ *     including when a readable prefix sits in front of the random part.
+ *
+ * Either way the WHOLE value has to be one token first
+ * ({@link OPAQUE_TOKEN_VALUE}). Carrying an identifier is not the same as being
+ * one: prose that quotes a trace id is still prose, and the sentence around the
+ * id is where the names are.
+ *
+ * Runs are measured BETWEEN separators and never across them. That is what
+ * keeps "maria.schmidt.1972" out: joined up it would clear the bar, but nobody
+ * types sixteen random characters in a row, and every segment of a written name
+ * is short. The same applies to "Elise-Marin-Van-Toren" and
+ * "Elm-Street-Apartment-4B".
+ *
+ * The digit requirement is what keeps "AnneMarieJohansson" out: it is one
+ * eighteen-character run, long enough on length alone, and only the absence of
+ * digits marks it as something a person wrote. Hex runs are exempt from the
+ * digit count because a sixteen-character identifier drawn entirely from a-f
+ * happens about once in eighty thousand, and no name is spelled in hex.
+ *
+ * THE RULE IS WRONG IN BOTH DIRECTIONS, KNOWINGLY.
+ *
+ * It withholds a name run together with a number, and not rarely: over a corpus
+ * of `<First><Last><year>` drawn from a seeded name list, about 91% are one run
+ * of sixteen or more characters carrying the two digits, so they are withheld
+ * and never analysed. "MariaSchmidt1972" is the shape, and this rule cannot
+ * tell it from a user id — which is what a value of that shape usually is.
+ * Widening the rule to catch it means dropping the digit count, and that puts
+ * every name back in scope of being withheld, so the residual is accepted
+ * rather than traded. It is the larger of the two residuals here and the one to
+ * reach for first if this rule is ever revisited.
+ *
+ * It fails to withhold a fair number of genuinely random tokens, because two
+ * digits is a real bar at short lengths and because `-` and `_` split a run:
+ * around 40% of nanoids and 17% of 32-character base64 tokens are submitted.
+ * Those are the analysis service's problem, not this rule's, and they are no
+ * worse off than before this rule existed.
+ *
+ * Counting `-` and `_` as part of a run is the obvious fix for the second
+ * residual and it is refused, because it has been measured: nanoid hold-out
+ * goes from about 59% to about 86%, and hyphenated names of the
+ * "Elise-Marin-1972" shape go from 0% withheld to 100% withheld. Recovering
+ * twenty-seven points of token protection by never analysing a hyphenated name
+ * again is the worse side of that trade in both directions at once.
+ */
+export function isOpaqueIdentifierValue(value: string): boolean {
+  if (value.length > MAX_IDENTIFIER_LENGTH) return false;
+  if (!OPAQUE_TOKEN_VALUE.test(value)) return false;
+  if (UUID_VALUE.test(value)) return true;
+
+  for (const [run] of value.matchAll(ALPHANUMERIC_RUN)) {
+    if (isOpaqueRun(run)) return true;
+  }
+  return false;
+}
+
+/**
+ * Whether one run between separators is longer and denser than a person writes:
+ * at least {@link MIN_OPAQUE_RUN_LENGTH} characters, carrying a letter, and
+ * either all hexadecimal or holding at least {@link MIN_DIGITS_IN_OPAQUE_RUN}
+ * digits. Both residuals this produces are set out on
+ * {@link isOpaqueIdentifierValue}, along with why neither is traded away.
+ */
+function isOpaqueRun(run: string): boolean {
+  if (run.length < MIN_OPAQUE_RUN_LENGTH) return false;
+  // A run with no letter is a digit run: a card, a phone, an account number.
+  if (!HAS_LETTER.test(run)) return false;
+  if (HEX_RUN.test(run)) return true;
+  return (run.match(/\d/g)?.length ?? 0) >= MIN_DIGITS_IN_OPAQUE_RUN;
+}
+
+/**
+ * Attribute names whose value is a trace or span address minted by a tracer.
+ *
+ * The shape rule above already covers the usual spellings, because a trace id is
+ * hex and a span id is hex. This list is for the ones it cannot see: a decimal
+ * trace id (what a B3 or Datadog bridge emits) carries no letter, so the shape
+ * rule reads it as a digit run and hands it to the recognizers. Naming the
+ * attribute settles it without asking what the value looks like.
+ *
+ * Compared lower-cased, so a dialect that writes `metadata.TraceId` is covered,
+ * and compared with each vendor namespace stripped, so the spellings the REST
+ * collector produces are covered too (see
+ * {@link isReservedIdentifierAttributeKey}).
+ * Keep this list short and keep it to addresses: a name here turns the whole
+ * personal-data pass off for that attribute — and then only for a value that is
+ * shaped like an address, see {@link reservesTraceAddress}.
+ */
+const RESERVED_IDENTIFIER_ATTRIBUTE_KEYS: ReadonlySet<string> = new Set([
+  "metadata.oteltraceid",
+  "metadata.otelspanid",
+  "metadata.traceid",
+  "metadata.spanid",
+  "metadata.trace_id",
+  "metadata.span_id",
+  "trace_id",
+  "span_id",
+  "traceid",
+  "spanid",
+]);
+
+/**
+ * Whether this attribute name is one of the reserved trace/span addresses.
+ *
+ * Matched on the bare spelling and on every vendor namespace that canonicalises
+ * to `metadata.<key>` ({@link METADATA_SUBKEY_PREFIXES}). Custom metadata does
+ * not always reach redaction spelled the way the caller wrote it: the REST
+ * collector rewrites each key to `langwatch.metadata.<key>` before dispatch,
+ * and the fold back to `metadata.<key>` runs in the projections — after
+ * redaction, which is to say after anything it destroyed is unrecoverable.
+ *
+ * Stripping the prefix here is deliberately preferred over listing each name
+ * once per namespace: a second copy of the list is a second thing to remember,
+ * and the copy that gets forgotten is the one that silently stops protecting
+ * anything. Only names ALREADY on the list are reached this way — a prefix
+ * widens the spellings, never the set of names.
+ *
+ * WHAT THIS DOES NOT COVER, STATED PLAINLY. It is a rule about attribute NAMES,
+ * so it only protects senders that put metadata in attribute names. That is the
+ * REST collector, and the Go SDK, which writes `metadata.<key>` directly. The
+ * Python and TypeScript SDKs do NOT: both send all custom metadata as one
+ * attribute literally named `metadata` holding a JSON blob, and the hoist to
+ * `metadata.<key>` happens during canonicalisation, after redaction. For those
+ * two SDKs the reserved names below never match, and a decimal trace id inside
+ * that blob is covered only by whatever the value rules make of the blob as a
+ * whole. Parsing the blob here is not the fix — that is the separate, already
+ * disclosed JSON residual, and it would mean re-serialising caller data inside
+ * the redaction path.
+ */
+export function isReservedIdentifierAttributeKey(key: string): boolean {
+  const lower = key.toLowerCase();
+  if (RESERVED_IDENTIFIER_ATTRIBUTE_KEYS.has(lower)) return true;
+  return METADATA_SUBKEY_PREFIXES.some(
+    (prefix) =>
+      lower.startsWith(prefix) &&
+      RESERVED_IDENTIFIER_ATTRIBUTE_KEYS.has(lower.slice(prefix.length)),
+  );
+}
+
+/**
+ * What a trace or span address is actually written as: hexadecimal (W3C, B3 and
+ * the OTel SDKs) or a decimal integer (the Datadog and B3 bridges, which is the
+ * case the reserved list exists for at all).
+ *
+ * The names above are NOT a protected namespace. Span attributes arrive on the
+ * OTLP endpoint exactly as the caller wrote them, so anyone can send
+ * `metadata.trace_id` holding an email address — and a name-only hold-out would
+ * then turn the personal-data pass off for it and store that email in the
+ * clear. Requiring the value to be address-shaped closes that without costing
+ * anything real: a value this rejects is still put to the ordinary
+ * {@link isOpaqueIdentifierValue} question, which is what catches a uuid-shaped
+ * or prefixed trace id. Only a value that is neither an address nor an opaque
+ * token loses the exemption, and that value was never an address.
+ */
+const TRACE_ADDRESS_VALUE = /^(?:[0-9a-f]{8,64}|\d{1,32})$/i;
+
+/**
+ * Whether this attribute is a reserved trace/span name carrying something that
+ * could be the address the name promises.
+ */
+export function reservesTraceAddress({
+  key,
+  value,
+}: {
+  key: string;
+  value: string;
+}): boolean {
+  return (
+    isReservedIdentifierAttributeKey(key) && TRACE_ADDRESS_VALUE.test(value)
+  );
+}
+
+/**
+ * Whether one attribute is held back from PII analysis altogether: reserved by
+ * name, or a value that is exclusively one opaque identifier token.
+ *
+ * Attribute values only. Free text — a log body, a status message, the chat
+ * content itself — is content by definition and always analysed.
+ */
+export function isHeldOutIdentifierAttribute({
+  key,
+  value,
+}: {
+  key: string;
+  value: string;
+}): boolean {
+  return reservesTraceAddress({ key, value }) || isOpaqueIdentifierValue(value);
+}

--- a/specs/data-privacy/pii-redaction.feature
+++ b/specs/data-privacy/pii-redaction.feature
@@ -174,6 +174,327 @@ Feature: Redacting personal data from traces
     When a trace is ingested with an attribute whose whole value is an email address with digits in it
     Then the stored attribute has the email address redacted
 
+  # The hold-out above only bites when nothing claims to have PROVEN its finding.
+  # A recognizer marked self-proving keeps running on an identifier-shaped value,
+  # on the promise that it carries a checksum or a marker no machine identifier
+  # holds by accident. Two of them did not keep that promise, and a trace id is
+  # not recoverable once a marker is written over it, because redaction runs
+  # before the event store.
+  #
+  # The bitcoin address pattern matched on shape alone - any 26 to 35 character
+  # token that starts with "1" or "3" and avoids the four look-alike characters -
+  # so roughly one in sixty random 32-character hex trace ids was stored as a
+  # crypto marker, at every level including the default. It now verifies the
+  # address checksum, so real addresses are still redacted and hex ids are not.
+  # The card pattern accepted any digit run that passes the Luhn check, which a
+  # thirteen-digit millisecond timestamp does about one time in ten. It now also
+  # asks whether a card scheme could have issued that number at that length,
+  # which the timestamps cannot be: the only scheme numbering from a leading one
+  # issues fifteen digits, and timestamps are thirteen, sixteen or nineteen. The
+  # rule is deliberately narrow, because a range excluded here is a real card
+  # number stored in the clear, so every other leading digit is still accepted.
+
+  @unit
+  Scenario: An opaque trace identifier survives redaction at the default level
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with an attribute whose whole value is a hex trace identifier starting with a one
+    Then the stored attribute still reads as it was sent
+
+  @unit
+  Scenario: A corpus of random hex identifiers survives the native engine intact
+    Given the resolved PII level for "web-app" is essential
+    When two thousand random hex trace identifiers are ingested as whole attribute values
+    Then every stored attribute still reads as it was sent
+
+  @unit
+  Scenario: A real bitcoin address is still redacted
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with an attribute whose whole value is a valid bitcoin address
+    Then the stored attribute has the address redacted
+
+  @unit
+  Scenario: A taproot address is still redacted
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with an attribute whose whole value is a valid taproot address
+    Then the stored attribute has the address redacted
+
+  # A checksum is only as narrow as the grammar behind it. The character after
+  # the "bc1" prefix is the witness version, read from a thirty-two character
+  # alphabet, and bitcoin defines only the first seventeen of those. A token
+  # carrying one of the other fifteen decodes to no address at all, so treating
+  # it as one would put a marker over a value that was never a payment address.
+  @unit
+  Scenario: A token using a witness version bitcoin does not define is not an address
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with an attribute holding a checksum valid token whose witness version is seventeen
+    Then the stored attribute still reads as it was sent
+
+  # The same argument one level down. A checksum covers the characters, not what
+  # they mean, so a token can clear it and still encode no output anyone could
+  # pay to: a payload that does not unpack to whole bytes, one shorter or longer
+  # than any witness program, or a version zero payload that is neither of the
+  # two lengths that version allows.
+  @unit
+  Scenario: A token whose witness program bitcoin does not allow is not an address
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with an attribute holding a checksum valid token whose witness program length is not one bitcoin allows
+    Then the stored attribute still reads as it was sent
+
+  # BIP-173 defines a segwit address as case-insensitive, and QR encoders emit
+  # the uppercase form because uppercase packs into a QR alphanumeric segment.
+  # A wallet address pasted from a QR scan is the same address as the lowercase
+  # one and is redacted the same way. Mixed case is not an address at all, and
+  # stays untouched.
+  @unit
+  Scenario: An uppercase segwit address is redacted like its lowercase form
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested whose input holds a segwit address written in uppercase
+    Then the stored input has the address redacted
+
+  @unit
+  Scenario: A millisecond timestamp is not read as a card number
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested whose input holds a thirteen digit millisecond timestamp that passes the Luhn check
+    Then the stored input still contains the timestamp
+
+  @unit
+  Scenario: A timestamp is not read as a card number at any of its widths
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested whose input holds millisecond, microsecond and nanosecond timestamps that pass the Luhn check
+    Then the stored input still contains every timestamp
+
+  @unit
+  Scenario: A timestamp from the 2040s is not read as a card number
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested whose input holds a Luhn passing number inside the Mastercard range at a width Mastercard does not issue
+    Then the stored input still contains the number
+
+  @unit
+  Scenario: Every card scheme in circulation is still redacted
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested whose input holds one valid card number from each scheme
+    Then the stored input has every card number redacted
+
+  @unit
+  Scenario: A card number written without separators is still redacted
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested whose input holds a card number written as one digit run
+    Then the stored input has the card number redacted
+
+  # The strict level adds names and locations, which need the external analysis
+  # service. That service guesses from wording, and an opaque identifier gives it
+  # nothing to go on, so it labels hex ids as people and places. Values are
+  # therefore filtered before they leave the process: an attribute whose whole
+  # value is one opaque identifier is never sent, and neither is an attribute
+  # under one of the reserved trace and span identifier names whose value is
+  # shaped like the address that name promises - hexadecimal, or a decimal run
+  # of at most thirty-two digits. The name alone withholds nothing: anyone who
+  # can write a span attribute can write one of those names, so a value that is
+  # not an address is analysed like any other, which is what keeps an email
+  # address parked under "metadata.trace_id" from being stored in the clear.
+  #
+  # "Opaque" has to be a high bar here, higher than the bar the native engine
+  # uses, because holding a value back from this service is what stops a name or
+  # a place ever being found in it. A value qualifies only when it carries a run
+  # of at least sixteen letters and digits that no person would type: a hex
+  # digest, or a run mixing letters with at least two digits. A hyphenated or
+  # run-together name - "Elise-Marin-Van-Toren", "AnneMarieJohansson",
+  # "Saint-Jean-Baptiste-Hospital" - has no such run, so it still goes for
+  # analysis and is still redacted.
+  #
+  # Correlation attributes a customer fills in themselves - the user, customer,
+  # thread and conversation identifiers - are deliberately NOT on the reserved
+  # list. Customers routinely put an email address in them, and never analysing
+  # them would store that email in the clear. They are covered by the same rule
+  # as every other attribute: held back when the whole value is one opaque
+  # identifier, analysed when it is personal data.
+
+  @unit
+  Scenario: An opaque identifier attribute value is never sent for analysis
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with an attribute whose whole value is a hex span identifier
+    Then the analysis service never received that value
+    And the stored attribute still reads as it was sent
+
+  @unit
+  Scenario: A reserved trace identifier attribute is never sent for analysis
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with a reserved trace identifier attribute
+    Then the analysis service never received that value
+
+  # The reserved names are not a namespace anyone owns. Attributes arrive on the
+  # ingestion endpoint spelled exactly as the sender wrote them, so a sender can
+  # put an email address under a trace identifier name - by mistake or on
+  # purpose - and a rule that went on the name alone would then store that email
+  # in the clear forever. The name earns the exemption only for a value that
+  # could be the address it promises, which is to say hexadecimal or decimal.
+  @unit
+  Scenario: A reserved trace identifier name holding an email address is redacted at the strict level
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with a reserved trace identifier attribute whose value is an email address
+    Then the stored attribute has the email address redacted
+    And the analysis service never received the email address in the clear
+
+  @unit
+  Scenario: A reserved trace identifier name holding an email address is still redacted
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with a reserved trace identifier attribute whose value is an email address
+    Then the stored attribute has the email address redacted
+
+  # A decimal trace identifier and a card number are the same shape, so no rule
+  # reading the value alone can separate them. What separates them is proof: the
+  # reserved name stands the shape-only detectors down, the way it does for any
+  # identifier, and leaves running the ones that can prove what they are looking
+  # at. A number carrying a card checksum inside a range a scheme actually
+  # issues is redacted whatever attribute it arrives under.
+  @unit
+  Scenario: A card number written under a reserved trace identifier name is still redacted
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with a reserved trace identifier attribute whose value is a valid card number
+    Then the stored attribute has the card number redacted
+
+  # The reserved names buy an exemption from the two secret rules that judge a
+  # token by its shape alone, because a trace identifier minted as a random body
+  # looks exactly as random as a key. "traceid" and "spanid" carry no
+  # underscore, so the ordinary rule for identifier-named attributes cannot
+  # reach them and the reserved list is the only thing that can.
+  #
+  # That exemption reads the value too. The ingestion endpoint forwards
+  # attribute names exactly as the sender wrote them, so a reserved name is a
+  # claim by whoever sent the span and nothing more; if the name alone bought
+  # the exemption, anyone could park a credential under "metadata.traceid" and
+  # keep the shape rules off it.
+  @unit
+  Scenario: A reserved trace identifier name keeps the address it promises
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with a reserved trace identifier attribute holding a decimal address
+    Then the stored attribute still reads as it was sent
+
+  @unit
+  Scenario: A reserved trace identifier name does not exempt a credential
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with a reserved trace identifier attribute holding a token only the shape rules can match
+    Then the stored attribute has the token redacted
+
+  # A decimal identifier of eleven digits is the shape of an international
+  # phone number, and nothing in the value says otherwise. It is the one
+  # decimal width where the reserved name changes what gets stored, which makes
+  # it the case worth stating: every other width survives redaction whether the
+  # name is reserved or not. The same value under an unreserved name is
+  # redacted, so what is being described here is the name and not the value.
+  @unit
+  Scenario: A decimal trace identifier a phone detector claims is kept under a reserved name
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with a reserved trace identifier attribute whose decimal value reads as a phone number
+    Then the stored attribute still reads as it was sent
+    And the same value under an unreserved attribute name has the phone number redacted
+
+  # The reserved list earns its keep on exactly this case, so it is worth
+  # stating on its own. The names without an underscore are the ones no other
+  # rule can reach: an attribute ending in "_id" is already exempt by a suffix
+  # rule older than this list, and a value long enough to look random is already
+  # held back by its shape. A short decimal address under a name like "traceid"
+  # has neither, so the reserved list is the only thing standing between it and
+  # a phone-number marker written over it permanently.
+  @unit
+  Scenario: A reserved name keeps an address the shape rule is too short to see
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with a short decimal trace address under a reserved name carrying no identifier suffix
+    Then the stored attribute still reads as it was sent
+    And the same value under an unreserved attribute name has the phone number redacted
+
+  # A customer sending metadata to the ingestion endpoint does not have it
+  # stored under the name they wrote. It is carried under one of the product's
+  # own namespaces through ingestion and put back to its plain name only once
+  # the trace is assembled, which is after redaction has had its say. There is
+  # more than one such namespace and they all collapse to the same plain name,
+  # so the reserved names have to be recognised under every spelling, or they
+  # protect only a caller writing raw OpenTelemetry attributes by hand.
+  #
+  # This covers senders that put metadata in attribute NAMES: the ingestion
+  # endpoint itself and the Go SDK. The Python and TypeScript SDKs send all
+  # custom metadata as a single JSON-encoded attribute, which is unpacked after
+  # redaction, so a reserved name inside that blob is not seen here at all.
+  @unit
+  Scenario: Caller metadata keeps a reserved trace identifier through the REST collector rewrite
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested whose caller metadata holds a reserved trace identifier written in decimal
+    Then the stored metadata still reads as it was sent
+    And the analysis service never received that value
+
+  @unit
+  Scenario: A corpus of opaque identifiers is never sent for analysis
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with attributes holding hex identifiers, dashed uuids and prefixed ULIDs
+    Then the analysis service received none of them
+
+  @unit
+  Scenario: A corpus of short opaque tokens is almost never sent for analysis
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with twelve hundred short hex span identifiers and prefixed ULIDs
+    Then the analysis service received fewer than one in a hundred of them
+
+  @unit
+  Scenario: A corpus of written names is still sent for analysis
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with two thousand generated names as attribute values
+    Then the analysis service received every one of them
+
+  @unit
+  Scenario: Prose that holds a name is still sent for analysis
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with an attribute whose value is a sentence naming a person
+    Then the analysis service received that sentence
+
+  # Holding a value back is decided on the WHOLE value, never on a part of it.
+  # Carrying an identifier is not the same as being one: a sentence that quotes
+  # a trace id is still a sentence, and the words around the id are exactly what
+  # the analysis pass exists to read. Deciding on a part would mean any message
+  # with a request id in it stopped being scanned for names.
+  @unit
+  Scenario: Prose that quotes an opaque identifier is still sent for analysis
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with an attribute whose value is a sentence naming a person next to a trace identifier
+    Then the analysis service received that sentence
+
+  @unit
+  Scenario: A customer identifier that holds a person name is still sent for analysis
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with a user identifier attribute whose value is a person name
+    Then the analysis service received that value
+
+  @unit
+  Scenario: A hyphenated or run-together name is still sent for analysis
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with attributes holding names written with hyphens, with dots and with no separator at all
+    Then the analysis service received every one of them
+
+  @unit
+  Scenario: A place written as one hyphenated token is still sent for analysis
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with an attribute whose value is a hyphenated place name
+    Then the analysis service received that value
+
+  @unit
+  Scenario: A reserved identifier attribute survives even when its value is all digits
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with a reserved trace identifier attribute written in decimal
+    Then the stored attribute still reads as it was sent
+
+  @unit
+  Scenario: Log attributes hold opaque identifiers back from analysis
+    Given the resolved PII level for "web-app" is strict
+    When a log record is ingested with an attribute whose whole value is a hex identifier
+    Then the analysis service never received that value
+    And the analysis service received the log body
+
+  @unit
+  Scenario: Metric attributes hold opaque identifiers back from analysis
+    Given the resolved PII level for "web-app" is strict
+    When a metric is ingested with one attribute holding a hex identifier and another holding prose
+    Then the analysis service never received the identifier
+    And the analysis service received the prose
+
   # Detection heuristics over-trigger on business identifiers that merely look
   # like PII: a 14-digit reservation number reads as a credit card, an
   # "orders@acme.internal" queue address reads as a personal email. Exception

--- a/specs/data-privacy/pii-redaction.feature
+++ b/specs/data-privacy/pii-redaction.feature
@@ -495,6 +495,17 @@ Feature: Redacting personal data from traces
     Then the analysis service never received the identifier
     And the analysis service received the prose
 
+  # A record can arrive keyed by a flattened path rather than by the attribute's
+  # own name, with a side table carrying the real names. The hold-out decides on
+  # the name, so it has to be told the real one on the submission path too, not
+  # only where the value is rewritten in place.
+  @unit
+  Scenario: A flattened attribute is held out under its real name
+    Given the resolved PII level for "web-app" is strict
+    When a log record is ingested with two flattened attributes carrying the same identifier, one named as a reserved trace address and one not
+    Then the analysis service received that value exactly once
+    And the analysis service received the log body
+
   # Detection heuristics over-trigger on business identifiers that merely look
   # like PII: a 14-digit reservation number reads as a credit card, an
   # "orders@acme.internal" queue address reads as a personal email. Exception


### PR DESCRIPTION
## For humans

When a customer sends us a trace, we scrub personal data out of it before we store
anything. That scrubbing was quietly eating the wrong things.

Two problems. First, the bitcoin-address detector was guessing from the *shape* of a
string rather than checking it, and a random trace id looks enough like a bitcoin
address to fool it — about 1 in 57 of them. Those ids were replaced with a
placeholder, and because the scrub happens before we write anything down, the
original was gone for good. The credit-card detector had the same weakness with long
number strings such as timestamps.

Second, at the strictest privacy setting we were shipping *every* attribute value out
to an external analysis service that looks for names and places. That service happily
decides a random hex id is a person's name, which destroyed it — and it also meant
opaque machine ids were leaving the process for no benefit at all.

This change makes both detectors actually verify what they claim, and adds one shared
rule that keeps opaque machine identifiers out of the external analysis. Real personal
data — emails, phone numbers, card numbers, names and places written in prose — is
still scrubbed exactly as before.

## Why

Redaction runs ahead of the event store, so anything it replaces is permanently lost.
Two recognizers claimed to prove their own findings and did not, and the strict-level
escalation submitted every attribute value to the external analysis service with no
filter at all. Between them, a few percent of every trace id, span id and record id we
ingest was being destroyed on the way in.

## What changed

**Native engine — the bitcoin recognizer now verifies, not guesses.**
It previously matched on shape alone: any 26 to 35 character token starting with `1`
or `3` that avoids the four base58 look-alike glyphs. On a seeded corpus of 2,000
random 32-character hex trace ids, 35 of them (1.75%) match that shape — and they were
destroyed at every PII level including the default, because the `isSelfProving` flag is
exactly what lets a recognizer keep running on a value the identifier hold-out would
otherwise protect.

It now verifies the base58check or bech32 checksum. The bech32 half validates the
grammar rather than only the checksum, because a bech32 checksum covers the characters
of a string and not what they mean: a token can clear thirty bits of checksum and still
encode no output anyone could pay to. So the witness version has to be one of the
sixteen BIP-141 defines, paired with the checksum constant BIP-350 requires for it, over
a program that repacks into two to forty whole bytes with zero padding bits — twenty or
thirty-two of them at version zero.

**Native engine — the card recognizer now needs an issuer range.**
It previously accepted any Luhn-passing run of 13 to 19 digits with no separator and no
context word. On a seeded corpus of 5,000 random digit runs of that width, 519 (10.4%)
clear Luhn. It now also requires an issuer range a payment card is actually minted
under, which brings the same corpus to 441 (8.8%).

The collision the check exists to break is a Unix timestamp. Every timestamp width in
use leads with a one, while the only scheme numbering from a one issues fifteen digits,
so length settles it. The Mastercard two-series window is held to sixteen digits, the
only length issued there — without that bound the whole check would have expired around
June 2040, when millisecond timestamps start with 22.

**Analysis-service path — one shared hold-out.**
`collectStringEntries` and `collectRecordEntries` pushed every non-empty string on the
span, log or metric. Both now consult one hold-out module before anything leaves the
process: an attribute whose *whole* value is one opaque identifier token is never
submitted, and neither is an attribute under a reserved trace or span identifier name
carrying a value that could be the address that name promises.

## How it works

The hold-out lives in one module both engines read, because a rule only one of them
knows about is a rule the other one undoes. It is deliberately narrow in both
directions, because the pass it gates is the only one that finds names and places — a
value it swallows is never scanned by anything, permanently.

- **A value is held back only when it is one token end to end.** Prose, minified JSON
  and URL paths that merely *quote* an identifier stay fully scanned, so a support note
  reading "<name> in <city> reported this on trace_<hex>" still has the name found.
- **A reserved name stands the shape-only recognizers down; it does not switch the
  personal-data pass off.** A number carrying a card checksum inside a range a scheme
  actually issues is redacted whatever attribute it arrives under.
- **The correlation attributes a customer fills in themselves** — user, customer, thread
  and conversation ids — are deliberately *not* reserved by name, because customers
  routinely put an email address or a full name in them. They are covered by the value
  rule like every other attribute.
- **The analysis path does not borrow the shape rule the native engine uses.** That rule
  calls any mixed-case sixteen-character run an identifier, which a hyphenated or
  run-together name is (`Elise-Marin-Van-Toren`, `AnneMarieJohansson`). Wired into the
  collector it would store those names in the clear. The native engine never had that
  problem because it has no notion of a person, which is why the two paths cannot share
  one rule.

## Test plan

Measured on this branch:

| Check | Result |
|---|---|
| `pnpm typecheck` | clean, exit 0 |
| `pnpm typecheck:all` | clean, exit 0 |
| `pnpm lint` | exit 0; 0 errors and 3,350 warnings, the same counts `main` produces. An earlier revision of this branch did add 14 Biome errors — unused imports, import order and formatting, all in files it introduces — and an earlier version of this table wrongly reported none, because the check had been run from the wrong package root. Fixed and re-measured from `platform/app`. |
| `pnpm test:unit run src/server/data-privacy src/server/app-layer/traces` | 111 files, 2,145 passed |
| same plus `src/server/tracer` | 128 files, 2,535 passed, 1 skipped |
| `check:feature-parity` | exit 0; `specs/data-privacy/pii-redaction.feature` 64/64 scenarios bound, 12,606 bound repo-wide |

New suites: `identifierHoldout.unit.test.ts`, `bitcoinAddress.unit.test.ts`,
`essentialPii.machineIdentifiers.unit.test.ts`, and a three-way split of the
service-level suite: `span-pii-redaction.identifierHoldout.harness.ts` holds the
fixtures and the service builder, `span-pii-redaction.identifierHoldout.test.ts`
asserts what the hold-out KEEPS, and `span-pii-redaction.analysisSubmission.test.ts`
asserts what still reaches the analysis service. Both suites drive the real service
and assert on the analysis boundary; the split is by which side of it they measure.

Every identifier fixture in these suites is generated from a seed the test names, not
observed in traffic. The one fixture that has to sit inside the base58 alphabet carries
an assertion pinning that shape, so a later substitution cannot make the test pass
vacuously.

## Anything surprising?

**The reserved-name catalog fired for nobody, and now fires under both spellings.**
Custom metadata does not reach redaction spelled the way the caller wrote it: the REST
collector rewrites every key to `langwatch.metadata.<key>` before the span is
dispatched (`collectorSpan.utils.ts:199`), and the canonicalisation back to
`metadata.<key>` runs in the projections — after redaction, which is to say after
anything redaction destroyed is already unrecoverable. The catalog listed only the bare
spelling, so it protected a hand-written OTLP attribute and nothing a first-party sender
emits. That was the form the earlier tests in this PR constructed, which is why they
passed on a rule that fired for no real traffic.

The name lookup now strips the vendor prefix once before comparing, rather than carrying
a second copy of the list. Only names already on the list are reachable that way — the
prefix widens the spellings, never the set of names — and raw OTLP callers are
unaffected. The value gate is untouched, so what a reserved name is allowed to excuse
has not moved: measured under both spellings, a payment card inside an issuer range, an
email address, an IBAN and a vendor credential are all still redacted under a reserved
name.

The suite gained a test that goes red when the catalog is emptied, which the previous
decimal test did not: it asserted that a 32-digit value survives, and 32 digits survive
with the catalog deleted, since no recognizer claims a run that long. Across the decimal
widths a bridge mints (10, 11, 12, 13, 19, 20, 32), the reserved name changes the stored
value in exactly one shape — eleven digits behind a leading one, which the phone
detector reads as an international number. That shape is the new fixture, with the same
value under an unreserved name as the control, so the test measures the name and not the
value.

### Review follow-ups in this branch

Five defects the reviews surfaced are fixed here, each with its own test:

- **A reserved name bought a secret-rule exemption on the name alone.** `metadata.trace_id`
  was already exempt by its `_id` suffix, which predates this list, but `traceid`,
  `spanid`, `oteltraceid` and `otelspanid` carry no underscore and were exempt because of
  the catalog and nothing else. The OTLP endpoint forwards attribute names as the sender
  wrote them, so a credential parked under `metadata.traceid` kept the two shape-only
  secret rules off it. A reserved name now buys no secret-rule exemption at all: the
  branch that granted it could never change an outcome — the values it admits are pure hex
  or pure decimal, while both shape-only rules require a `_` or `-` in the token — so it
  was removed rather than value-gated. Only the older `_id` suffix rule grants that skip.
- **The vendor-namespace strip was wrong in both directions at once.** Reserved names are
  matched with the vendor namespace stripped, because redaction sees the prefixed spelling
  and the fold back to `metadata.<key>` happens afterwards. Stripping a bare `langwatch.`
  both over- and under-reached: `langwatch.trace.trace_id` was missed, though the
  canonicaliser folds `langwatch.trace.` and `langwatch.metadata.` to the same name, while
  `langwatch.trace_id` and `langwatch.traceid` were accepted even though nothing folds
  them to a reserved name. The prefixes now come from one exported constant,
  `METADATA_SUBKEY_PREFIXES`, that the canonicaliser and the hold-out both read, so the
  two cannot drift; a test loops over that constant rather than over a literal list.
- **The reserved-name half does not cover the Python and TypeScript SDKs, and a comment
  claimed it did.** Those SDKs send all custom metadata as a single attribute literally
  named `metadata` holding a JSON blob, unpacked to `metadata.<key>` during
  canonicalisation — after redaction. The name rule therefore protects the REST collector
  and the Go SDK, which writes `metadata.<key>` directly, and not those two. Parsing the
  blob inside the redaction path is not the fix and is the separate JSON residual already
  noted below; the claim is corrected in the code and in the feature file instead.
- **`isBase58CheckAddress` accepted any version byte.** Version `0x06` renders with a
  leading `3`, satisfies the legacy pattern, carries a valid checksum, and was replaced
  with `[CRYPTO]` — a false positive of exactly the kind this branch removes. Mainnet
  mints `0x00` and `0x05`; the other 254 values are rejected.
- **Uppercase segwit addresses were never redacted.** BIP-173 makes an address
  case-insensitive and QR encoders emit the uppercase form. The router tested a lowercase
  `bc1` only, so that form went to the base58 decoder and came back "not an address". The
  CRYPTO pattern now carries an explicit uppercase branch — written out rather than
  carried by an `i` flag, which applies to the whole pattern and would let the legacy
  class accept `0`, `O`, `I` and `l`. Mixed case stays invalid.

The hold-out suite is split into what the rule keeps and what still reaches analysis over
a shared harness, and the feature file no longer claims a reserved name withholds a value
"whatever it holds" — it has always required an address shape.

**Known residuals, measured on this branch** (5,000 generated values per corpus, one
seed):

- An identifier embedded in a larger JSON blob attribute is still submitted to the
  analysis service. The hold-out reads whole values, by design — that is the same
  property that keeps prose scannable.
- **A run-together name carrying digits is withheld from analysis, and not rarely.** A
  surname followed by a year of birth is a sixteen-character run with digits, which this
  rule cannot tell from a user id — and a value of that shape usually is one. Measured on
  this branch over 2,000 seeded `<First><Last><year>` values per seed: 90.7%, 92.8% and
  91.9% withheld. This is the larger of the two hold-out residuals and the first place to
  look if the rule is revisited.

  The obvious widening costs more than it returns. Counting `-` and `_` as part of a run
  lifts nanoid hold-out from 58.6/62.0/59.3% to 84.6/87.8/86.8%, and takes hyphenated
  names of the `Elise-Marin-1972` shape from 0% withheld to **100%** withheld. Refused in
  both directions; the numbers are in the `isOpaqueIdentifierValue` docstring.
- The opaque-token hold-out is partial. Tokens *not* held back: nanoid-style 21-char
  tokens 40.7%, base64 of 16 random bytes 47.3%, base64url of 16 random bytes 40.1%,
  hex 32-char 0.0%. Hex ids — the shape that matters most here — are fully covered;
  higher-alphabet tokens are not, because `+`, `/` and `-` split a run and the rule
  measures runs between separators.
- An arbitrary Luhn-valid digit run not under an identifier-shaped key still reads as a
  card 8.8% of the time, against 10.4% before this change. The improvement is the issuer
  range; the remainder is inherent to Luhn.
- **A decimal trace id can still be stored as `[CREDIT_CARD]` under a reserved name.**
  A Datadog or B3 bridge mints a uint64 id, which is 19 or 20 decimal digits; when a
  19-digit one both passes Luhn and opens on an issuer range, the card recognizer takes
  it and the reserved name does not outrank it. Measured on this branch over 2,000
  generated 19-digit ids under `metadata.trace_id`: 146 redacted, 7.3%. At 20 digits it
  is 0%, because the recognizer stops at 19. This is a deliberate open trade-off — the
  name says address, the value carries a payment-card checksum, and preferring the name
  would mean a real card pasted under a trace-id key is stored in the clear. Left for a
  separate change rather than settled quietly here.
- **An attribute key ending `_id` or `.id`, or equal to `id`, is exempt from the two
  shape-only secret heuristics regardless of what it holds.** This is
  `isIdentifierAttributeName`, it reads the name and never the value, and it predates this
  branch — untouched here. The consequence: a credential that *only* a shape heuristic can
  match, with no vendor namespace and no credential word near it, is stored verbatim under
  such a key.

  The bound is measured, not a sample. `BUILTIN_SECRET_RULES` holds 18 rules and the
  skip list names exactly 2 of them, `prefixed_hex_api_key` and `shaped_api_key`, so the
  other **16 of 18 still read the value** under such a key. The list has exactly two
  consumers, both in `packages/redaction/src/secrets.ts` (`redactSecretsInText` and
  `detectSecretsInText`, via `toSkipSet`); nothing else consults it, so there is no third
  path where the exemption could widen. What still runs:
  vendor namespaces, armour, URL passwords, authorization schemes, credential keywords, the
  customer's own custom patterns, and the whole personal-data pass. Verified end to end on
  this branch under `metadata.trace_id`, `langwatch.metadata.trace_id` and an unreserved
  `metadata.request_id` control: `sk-ant-…` and `AKIA…` are replaced with `[SECRET]` under
  all three; a `prefix_<random body>` token that only `shaped_api_key` can match is kept
  under all three.

  This is the *secret* lane only. The reserved catalog's other effect — treating the
  value as identifier-shaped, which exempts it from the shape-only *personal-data*
  recognizers — does not come from `isIdentifierAttributeName`, so on that side the
  catalog does newly change behaviour for `_id` spellings too: `metadata.trace_id`
  holding an 11-digit decimal address is stored verbatim here where on `main` it was
  `[PHONE_NUMBER]`. That change is deliberate and is the scenario at
  `specs/data-privacy/pii-redaction.feature:386`.

  Not fixed here because narrowing it would take the exemption off `scenario.run_id`,
  `langwatch.prompt.id`, `gen_ai.conversation.id`, `metadata.user_id` and the rest of the
  ingestion vocabulary — a record id minted as `prefix_<random body>` is exactly what the
  shape rules are tuned to take, which is the defect this hold-out exists to fix. The
  reserved trace and span names are gated on the value instead, because that list is new
  and nothing depends on it being name-only.
- The opaque-token hold-out's cost is the *submission*, not the loss. Roughly 40% of
  nanoid-style tokens are submitted to the analysis service at strict (39.5%, 41.5% and
  41.6% over three seeds, 2,000 values each, re-measured on this branch). What fraction
  of a submitted token comes back labelled `[PERSON]` or `[LOCATION]` is the service's
  own error rate and is **not** measured here — the suites mock the service, so any
  figure for it would be borrowed rather than reproduced. It is the number that turns
  this residual from a submission into permanent destruction, and it is the open
  question this PR does not answer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced false-positive redaction of machine identifiers, including trace/span IDs, UUIDs, tokens, and timestamp-like values.
  - Improved payment-card detection using issuer-range and checksum validation.
  - Improved Bitcoin address detection with checksum and witness-program validation, including uppercase SegWit addresses.
  - Preserved redaction of genuine payment cards, Bitcoin addresses, emails, names, and other personal data.
  - Excluded opaque identifiers from PII analysis across spans, logs, metrics, and caller metadata.

- **Documentation**
  - Added coverage for updated redaction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





