### PR TITLE
fix(ci): the parity lists 7960 and 8041 both wrote, and the mint audit row the test read too early

### DIFF
--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -313,8 +313,6 @@ const LEGACY_INERT: string[] = [
   "specs/ai-gateway/governance/routing-policy-aliases-and-rules.feature",
   "specs/ai-gateway/governance/routing-policy-scope-cascade.feature",
   "specs/ai-gateway/governance/self-hosted-setup.feature",
-  "specs/ai-gateway/governance/sessions-and-devices.feature",
-  "specs/ai-gateway/governance/siem-export.feature",
   "specs/ai-gateway/governance/template-cross-bind-guard.feature",
   "specs/ai-gateway/governance/template-ottl-authoring.feature",
   "specs/ai-gateway/governance/template-ottl-principal-guard.feature",
@@ -688,6 +686,12 @@ const LEGACY_PARTIAL: string[] = [
   "specs/ai-gateway/governance/ingestion-sources.feature",
   "specs/ai-gateway/governance/ingestion-templates-catalog.feature",
   "specs/ai-gateway/governance/my-usage-dashboard.feature",
+  // Reason: #7960 tagged and bound the four scenarios the devices tab now
+  // answers, and retired its LEGACY_INERT entry. The eight untagged ones
+  // describe the org-wide max-session-duration policy and the admin sessions
+  // widget, neither of which is built, and the bulk revoke of every
+  // credential class at once, which is.
+  "specs/ai-gateway/governance/sessions-and-devices.feature",
   // Reason: #8041 tagged and bound two scenarios (opaque id placement on
   // export, and the drop of an opaque email beside a user id) and retired
   // its LEGACY_INERT entry. The eleven untagged scenarios describe the wider
@@ -703,6 +707,12 @@ const LEGACY_PARTIAL: string[] = [
   "specs/ai-governance/cli-onboarding/login-unified.feature",
   "specs/ai-governance/cli-wrappers/cli-mints-ingest-key.feature",
   "specs/ai-governance/cli-wrappers/latest-login-wins.feature",
+  // Reason: #7960 tagged and bound the scenario for logout retiring the
+  // ingest keys its session minted, and retired the file's LEGACY_INERT
+  // entry. The twenty-one untagged ones describe the rest of what logout
+  // unwires locally, settings.json, the plugin, the codex blocks and the
+  // shell rc, which that change did not touch.
+  "specs/ai-governance/cli-wrappers/logout.feature",
   "specs/ai-governance/cli-wrappers/shell-rc-persistence.feature",
   "specs/ai-governance/personal-portal/admin-catalog-editor.feature",
   "specs/ai-governance/personal-portal/tool-catalog-rbac.feature",
@@ -1919,8 +1929,37 @@ interface ParityAnalysis {
   listErrors: string[];
 }
 
+/**
+ * `LEGACY_INERT` says a file yields NO enforced scenario. `LEGACY_UNBOUND` and
+ * `LEGACY_PARTIAL` both say it yields some. A file on the inert list and on
+ * either of the other two is therefore always a mistake, and it is one two
+ * branches can make without conflicting: one tags a scenario in the file and
+ * moves it to `LEGACY_PARTIAL`, the other leaves it untagged and adds it to
+ * `LEGACY_INERT`, and main gets both. The stale-entry check then fails on the
+ * copy that no longer describes the file, which is what this catches first.
+ *
+ * `LEGACY_UNBOUND` and `LEGACY_PARTIAL` are not exclusive of each other: a
+ * file can have enforced scenarios that are unbound and untagged ones beside
+ * them, and it needs both entries to be tolerated.
+ */
+function validateNoCrossListEntries(): string[] {
+  const inert = new Set(LEGACY_INERT);
+  return [
+    { name: "LEGACY_UNBOUND", entries: LEGACY_UNBOUND },
+    { name: "LEGACY_PARTIAL", entries: LEGACY_PARTIAL },
+  ].flatMap(({ name, entries }) =>
+    entries
+      .filter((entry) => inert.has(entry))
+      .map(
+        (entry) =>
+          `${entry} is listed in LEGACY_INERT and ${name} — the first says the file enforces nothing, the second says it enforces something, keep the one that matches the file and delete the other`,
+      ),
+  );
+}
+
 function validateAllExemptionLists(allFeatures: string[]): string[] {
   return [
+    ...validateNoCrossListEntries(),
     ...validateExemptionList({
       name: "LEGACY_UNBOUND",
       entries: LEGACY_UNBOUND,

--- a/platform/app/src/mcp/__tests__/governance-tools.audit-uniform.integration.test.ts
+++ b/platform/app/src/mcp/__tests__/governance-tools.audit-uniform.integration.test.ts
@@ -19,7 +19,7 @@
 
 import { PersonalWorkspaceService } from "@ee/governance/services/personalWorkspace.service";
 import { nanoid } from "nanoid";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import {
   OrganizationUserRole,
   RoleBindingScopeType,
@@ -216,12 +216,17 @@ describe("governance MCP tools — audit-uniform contract", () => {
       expect(minted).not.toMatch(/^FORBIDDEN|^AUTH_REQUIRED/);
       const apiKeyId = (JSON.parse(minted) as { apiKeyId: string }).apiKeyId;
 
-      const mintAudit = await prisma.auditLog.findFirst({
-        where: { organizationId: ORG_ID, action: "ingestionKey.mint" },
-        orderBy: { createdAt: "desc" },
+      // The mint does not wait on its audit row: a write that fails must not
+      // swallow a token the response shows exactly once. So the row lands
+      // shortly after the answer, not before it.
+      await vi.waitFor(async () => {
+        const mintAudit = await prisma.auditLog.findFirst({
+          where: { organizationId: ORG_ID, action: "ingestionKey.mint" },
+          orderBy: { createdAt: "desc" },
+        });
+        expect(mintAudit?.metadata).toMatchObject({ surface: "mcp" });
+        expect(mintAudit?.args).toMatchObject({ apiKeyId });
       });
-      expect(mintAudit?.metadata).toMatchObject({ surface: "mcp" });
-      expect(mintAudit?.args).toMatchObject({ apiKeyId });
 
       const revoked = await call(mock, "governance_ingestion_keys_revoke", {
         api_key_id: apiKeyId,


### PR DESCRIPTION
main has been red since #7960 merged. Run [34688817690](https://github.com/langwatch/langwatch/actions/runs/34688817690) failed two jobs, `feature-parity` and `test-integration (shared 1/2)`. Both come from that merge and both are fixed here.

## feature-parity

Four complaints, one cause and two follow-ons.

`specs/ai-gateway/governance/siem-export.feature` was already in `LEGACY_PARTIAL`, put there by #8041 when it tagged and bound two of its scenarios. #7960 added the same file to `LEGACY_INERT`. Neither branch touched the other's line, so git merged both cleanly and main got a file declared to enforce nothing and to enforce something. The stale-entry check then failed on the `LEGACY_INERT` copy. Removed, the `LEGACY_PARTIAL` entry is the one that matches the file.

`specs/ai-gateway/governance/sessions-and-devices.feature` had four scenarios tagged and bound by #7960 but kept its `LEGACY_INERT` entry. It moves to `LEGACY_PARTIAL`: the eight untagged scenarios describe the org-wide max-session-duration policy and the admin sessions widget, neither built, plus the bulk revoke of every credential class, which is. None of them can honestly take a binding tag here.

`specs/ai-governance/cli-wrappers/logout.feature` correctly left `LEGACY_INERT` when #7960 bound its ingest-key scenario, but never got the `LEGACY_PARTIAL` entry its other twenty-one scenarios need. Those describe the rest of what logout unwires locally, settings.json, the plugin, the codex blocks and the shell rc, which that change did not touch. Added, with the reason.

Every untagged scenario stays in place. Tagging them would claim coverage that does not exist, and deleting them would drop behavior the product has.

The check also refuses, up front, a file listed in `LEGACY_INERT` and in either of the other two lists. `LEGACY_INERT` says the file enforces nothing, the other two say it enforces something, so a file on both is always a mistake, and it is one two branches can make without conflicting. The existing stale-entry check only notices afterwards, on whichever copy stopped matching, which is why this reached main. `LEGACY_UNBOUND` and `LEGACY_PARTIAL` stay compatible with each other, since a file can have unbound enforced scenarios and untagged ones beside them, and `specs/langy/langy-projection-independent-reactions.feature` legitimately has both entries.

`node platform/app/scripts/check-feature-parity.ts` now exits 0 with no failure line.

## test-integration (shared 1/2)

Ours, not a flake.

```
FAIL src/mcp/__tests__/governance-tools.audit-uniform.integration.test.ts
  > when an MCP tool mints and then revokes an ingestion key
  > stamps metadata.surface=mcp on both rows, the revoke before it answers
AssertionError: expected undefined to match object { surface: 'mcp' }
```

The test is #7960's own, and so is the behavior it races. `governance_ingestion_keys_mint` writes its audit row with `void auditLog(...)` on purpose: a write that fails must not swallow a token the response shows exactly once. The revoke below it awaits its row, and the test says so in a comment. The mint assertion read the row straight after the tool answered, so on a slow run there was no row yet, which is what `Received: undefined` is.

The assertion now waits for the row, the same `vi.waitFor` shape the organization-members REST test uses for its fire-and-forget audit write. The production path is unchanged, the non-blocking mint is the right call.

## Gates

- `node platform/app/scripts/check-feature-parity.ts` clean
- `pnpm typecheck:all` clean
- `pnpm test:integration src/mcp/__tests__/governance-tools.audit-uniform.integration.test.ts --watch=false` passing, 3 tests
- biome on both touched files reports only the pre-existing complexity warnings, on functions this change does not touch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Improved validation of legacy feature classifications to detect conflicting entries and support more accurate feature parity tracking.
  - Updated feature status coverage for sessions, devices, logout, and SIEM export capabilities.

- **Quality Improvements**
  - Improved audit verification reliability by allowing audit records to finish processing before validation, reducing intermittent test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->