### PR TITLE
fix: await organization provisioning audit

### DIFF
--- a/platform/app/src/app/api/organizations/[[...route]]/app.ts
+++ b/platform/app/src/app/api/organizations/[[...route]]/app.ts
@@ -209,10 +209,10 @@ secured
         throw error;
       }
 
-      // Fire-and-forget like every other management audit, but with the
-      // rejection handled: `void` alone silences the lint rule and leaves an
-      // unhandled rejection when the audit insert fails.
-      void auditLog({
+      // Wait until issuance is recorded before returning the one-time token.
+      // Audit failure is still non-fatal: the organization and key already
+      // exist, and turning this into a 500 would make the token unrecoverable.
+      await auditLog({
         userId: "instance-admin",
         organizationId: created.organization.id,
         action: "management.organization.provision",

--- a/platform/app/src/app/api/organizations/__tests__/organizations-provisioning-rest-api.integration.test.ts
+++ b/platform/app/src/app/api/organizations/__tests__/organizations-provisioning-rest-api.integration.test.ts
@@ -10,6 +10,7 @@
  * the credential is not configured or the deployment is cloud.
  */
 import { nanoid } from "nanoid";
+import { auditLog } from "@ee/audit-log/auditLog";
 import {
   afterAll,
   afterEach,
@@ -30,6 +31,10 @@ import { prisma } from "~/server/db";
 import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
 import { ENTERPRISE_TEST_PLAN } from "~/test-utils/managementApiOrg";
 import { app } from "../[[...route]]/app";
+
+vi.mock("@ee/audit-log/auditLog", () => ({
+  auditLog: vi.fn().mockResolvedValue(undefined),
+}));
 
 describe("Feature: Organization provisioning REST API for self-hosted deployments", () => {
   // Slugs are lowercase-and-hyphens by contract, and nanoid's alphabet is
@@ -84,6 +89,7 @@ describe("Feature: Organization provisioning REST API for self-hosted deployment
     // starts from the configured, self-hosted baseline.
     process.env.LANGWATCH_INSTANCE_ADMIN_API_KEY = instanceKey;
     installSelfHostedApp();
+    vi.mocked(auditLog).mockReset().mockResolvedValue(undefined);
   });
 
   afterAll(async () => {
@@ -137,6 +143,52 @@ describe("Feature: Organization provisioning REST API for self-hosted deployment
       const organization = await managed.json();
       expect(organization.id).toBe(body.organization.id);
       expect(organization.slug).toBe(`prov-acme-${ns}`);
+    });
+
+    /** @scenario The bootstrap credential is not returned before its audit record is durable */
+    it("waits for the provisioning audit before returning the bootstrap credential", async () => {
+      let releaseAudit!: () => void;
+      let auditStarted!: () => void;
+      const started = new Promise<void>((resolve) => {
+        auditStarted = resolve;
+      });
+      const pendingAudit = new Promise<void>((resolve) => {
+        releaseAudit = resolve;
+      });
+      vi.mocked(auditLog).mockImplementationOnce(async () => {
+        auditStarted();
+        await pendingAudit;
+      });
+
+      let responded = false;
+      const responsePromise = provision({
+        name: "Audited",
+        slug: `prov-audited-${ns}`,
+      }).then((response) => {
+        responded = true;
+        return response;
+      });
+
+      await started;
+      expect(responded).toBe(false);
+
+      releaseAudit();
+      const response = await responsePromise;
+      expect(response.status).toBe(201);
+      expect((await response.json()).adminApiKey.token).toContain("sk-lw-");
+    });
+
+    /** @scenario An unavailable audit store does not lose the one-time bootstrap credential */
+    it("returns the bootstrap credential when the audit write rejects", async () => {
+      vi.mocked(auditLog).mockRejectedValueOnce(new Error("audit unavailable"));
+
+      const response = await provision({
+        name: "Audit Failure",
+        slug: `prov-audit-failure-${ns}`,
+      });
+
+      expect(response.status).toBe(201);
+      expect((await response.json()).adminApiKey.token).toContain("sk-lw-");
     });
 
     /** @scenario A slug outside the documented shape is refused */

--- a/specs/organizations/organizations-provisioning-rest-api.feature
+++ b/specs/organizations/organizations-provisioning-rest-api.feature
@@ -29,6 +29,19 @@ Feature: Organization provisioning REST API for self-hosted deployments
     And that key can immediately manage the new organization
 
   @integration
+  Scenario: The bootstrap credential is not returned before its audit record is durable
+    When I create an organization while its provisioning audit is still being written
+    Then the response remains pending
+    And the response status is 201 after the audit write completes
+    And it carries the bootstrap admin API key
+
+  @integration
+  Scenario: An unavailable audit store does not lose the one-time bootstrap credential
+    When I create an organization while its provisioning audit write fails
+    Then the response status is 201
+    And it still carries the bootstrap admin API key
+
+  @integration
   Scenario: A slug outside the documented shape is refused
     When I create an organization with a slug that is not lowercase letters, digits and hyphens
     Then the request is refused with status 422


### PR DESCRIPTION
## Why

Closes #8100. Organization provisioning returned the one-time bootstrap admin token before its audit row was durable, leaving a crash window in which the credential could be issued without an audit record.

## What changed

- Await the provisioning audit write before returning the token.
- Preserve the existing non-fatal audit failure behavior so an already-created, unrecoverable token is not hidden behind a 500.
- Add specification scenarios and integration coverage for ordering and audit-store failure.

## How it works

The route now awaits the existing `auditLog(...).catch(...)` promise. Successful writes therefore become durable before the response, while caught write failures still allow the response to carry the only copy of the generated credential.

## Test plan

- Added two `@integration` scenarios and matching `@scenario` tests.
- The integration runner reached global setup but could not execute locally because the required `goose` binary is not installed; CI should run the new coverage.
- `git diff --check` passed before commit.

## Anything surprising

Audit failure intentionally remains non-fatal because returning 500 after organization/key creation would permanently lose the one-time token.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Organization provisioning responses now wait for audit logging to complete before returning the one-time bootstrap credential.
  - Audit logging failures no longer prevent successful provisioning responses or credential delivery.
- **Tests**
  - Added coverage for delayed audit logging and audit logging failures during organization provisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->